### PR TITLE
Align MCP tool naming to AHK_ convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ---
 
 > [!IMPORTANT]
-> UPDATED 9/23/25: Enhanced script execution with window detection and state validation. The `ahk_run` tool now detects when AutoHotkey scripts launched by monitoring for new windows. Added debug logging for MCP tool calls and improve file path process. Fixed tool naming consistency across the entire codebase.
+> UPDATED 9/23/25: Enhanced script execution with window detection and state validation. The `AHK_Run` tool now detects when AutoHotkey scripts launched by monitoring for new windows. Added debug logging for MCP tool calls and improve file path process. Fixed tool naming consistency across the entire codebase.
 > This readme was not created using AI, so it's worth reading lol
 
 ## Overview
@@ -173,9 +173,15 @@ Add the server to your Claude Desktop configuration file (`claude_desktop_config
 
 ## MCP Tools
 
+### Tool Naming Convention
+
+- All tools now use the `AHK_<Word>_<Word>` format (e.g. `AHK_File_View`, `AHK_File_Edit_Diff`).
+- Previous lowercase names such as `ahk_file_view` are no longer registered by the server.
+- Mixing the old names in tool chains previously triggered "Unknown tool" errors because `server.ts` only dispatched `ahk_*` handlers. The dispatcher, tool recommendations, and configuration settings now agree on the new `AHK_*` identifiers so chained calls proceed correctly.
+
 ### Core Analysis Tools
 
-#### `ahk_run`
+#### `AHK_Run`
 Execute AutoHotkey scripts with window detection and timeout handling.
 
 ```typescript
@@ -190,7 +196,7 @@ Execute AutoHotkey scripts with window detection and timeout handling.
 }
 ```
 
-#### `ahk_diagnostics`
+#### `AHK_Diagnostics`
 Validates code syntax and enforces coding standards with detailed error reporting.
 
 ```typescript
@@ -201,7 +207,7 @@ Validates code syntax and enforces coding standards with detailed error reportin
 }
 ```
 
-#### `ahk_analyze`
+#### `AHK_Analyze`
 Comprehensive script analysis with contextual documentation and usage insights.
 
 ```typescript

--- a/Tests/test-mcp-run.js
+++ b/Tests/test-mcp-run.js
@@ -39,12 +39,12 @@ async function main() {
 
   // Set active file
   const setActId = nextId();
-  send({ jsonrpc: '2.0', id: setActId, method: 'tools/call', params: { name: 'ahk_active_file', arguments: { action: 'set', filePath: script } } });
+  send({ jsonrpc: '2.0', id: setActId, method: 'tools/call', params: { name: 'AHK_Active_File', arguments: { action: 'set', filePath: script } } });
   await onceMessage();
 
-  // Call ahk_run without filePath to use activeFile fallback, powershell runner
+  // Call AHK_Run without filePath to use activeFile fallback, powershell runner
   const runId = nextId();
-  send({ jsonrpc: '2.0', id: runId, method: 'tools/call', params: { name: 'ahk_run', arguments: { mode: 'run', ahkPath: ahkExe, runner: 'powershell', wait: true } } });
+  send({ jsonrpc: '2.0', id: runId, method: 'tools/call', params: { name: 'AHK_Run', arguments: { mode: 'run', ahkPath: ahkExe, runner: 'powershell', wait: true } } });
   const runResp = await onceMessage();
   console.error('runResp:', JSON.stringify(runResp));
 

--- a/Tests/test-multiline-input.md
+++ b/Tests/test-multiline-input.md
@@ -53,19 +53,19 @@ Include logging
 ### With Claude + MCP:
 
 1. **Direct Tool Call**: 
-   Use `ahk_process_request` tool with the multi-line input
+   Use `AHK_Process_Request` tool with the multi-line input
 
 2. **Auto-Detection**:
-   Use `ahk_auto_file` to detect and set from any text
+   Use `AHK_File_Detect` to detect and set from any text
 
 3. **Manual Process**:
-   - First: `ahk_auto_file` to set the file
+   - First: `AHK_File_Detect` to set the file
    - Then: Use any tool without specifying path
 
 ### Example MCP Request:
 ```json
 {
-  "tool": "ahk_process_request",
+  "tool": "AHK_Process_Request",
   "arguments": {
     "input": "C:\\Scripts\\test.ahk\n\nCheck for errors and run it",
     "autoExecute": true,

--- a/Tests/test-window-detection-mock.js
+++ b/Tests/test-window-detection-mock.js
@@ -60,7 +60,7 @@ console.log('• Works with wait: false for non-blocking execution');
 console.log('• Visual feedback: "✅ Window detected: [Title]" or "⏳ No window detected"');
 
 console.log('\n🎯 Usage Example:');
-console.log('ahk_run({');
+console.log('AHK_Run({');
 console.log('  mode: "run",');
 console.log('  filePath: "MyGUIScript.ahk",');
 console.log('  wait: false,');

--- a/demos/simple-mcp-sse.cjs
+++ b/demos/simple-mcp-sse.cjs
@@ -110,7 +110,7 @@ function handleMCPMessage(req, res) {
             }
           },
           {
-            name: 'ahk_analyze',
+            name: 'AHK_Analyze',
             description: 'Analyze AutoHotkey v2 code for syntax, patterns, and best practices',
             inputSchema: {
               type: 'object',
@@ -213,7 +213,7 @@ function handleMCPMessage(req, res) {
       }
     });
 
-  } else if (message.method === 'tools/call' && message.params.name === 'ahk_analyze') {
+  } else if (message.method === 'tools/call' && message.params.name === 'AHK_Analyze') {
     const code = message.params.arguments.code;
     const analysis = {
       lineCount: code.split('\n').length,
@@ -312,7 +312,7 @@ app.get('/', (req, res) => {
             </div>
             <div class="endpoint">
                 <h3>Tools Available</h3>
-                <p><code>search</code>, <code>fetch</code>, <code>ahk_analyze</code></p>
+                <p><code>search</code>, <code>fetch</code>, <code>AHK_Analyze</code></p>
                 <p>Search docs, fetch details, analyze code</p>
             </div>
             <div class="endpoint">

--- a/docs/ACTIVE_FILE_USAGE.md
+++ b/docs/ACTIVE_FILE_USAGE.md
@@ -32,7 +32,7 @@ Run this script and check if the window appears
 
 ## Available Tools
 
-### 1. `ahk_process_request`
+### 1. `AHK_Process_Request`
 **Primary tool for handling file paths with instructions**
 
 This tool automatically:
@@ -55,7 +55,7 @@ Response:
 [Results shown]
 ```
 
-### 2. `ahk_auto_file`
+### 2. `AHK_File_Detect`
 **Explicitly detect and set active files**
 
 Use when you want to:
@@ -63,7 +63,7 @@ Use when you want to:
 - See all detected paths in a message
 - Manually control active file setting
 
-### 3. `ahk_active_file`
+### 3. `AHK_Active_File`
 **Get or set the current active file**
 
 Actions:
@@ -88,7 +88,7 @@ The system intelligently detects what you want to do based on keywords:
 If your scripts are in a specific folder:
 
 ```javascript
-// Using ahk_auto_file tool
+// Using AHK_File_Detect tool
 {
   "text": "Set my script directory",
   "scriptDir": "C:\\MyScripts"
@@ -157,10 +157,10 @@ Output:
 
 Once an active file is set:
 
-- **`ahk_run`**: Runs without needing file path
-- **`ahk_diagnostics`**: Can analyze the active file's code
+- **`AHK_Run`**: Runs without needing file path
+- **`AHK_Diagnostics`**: Can analyze the active file's code
 - **Direct edits**: Work on the active file
-- **`ahk_debug_agent`**: Debug the active script
+- **`AHK_Debug_Agent`**: Debug the active script
 
 ## Tips
 
@@ -178,7 +178,7 @@ Once an active file is set:
 
 ### Wrong Action Detected
 - Be more explicit with keywords
-- Use `defaultAction` parameter in `ahk_process_request`
+- Use `defaultAction` parameter in `AHK_Process_Request`
 - Or call specific tools directly
 
 ### Path Not Detected

--- a/docs/ALPHA_SYSTEM_SUMMARY.md
+++ b/docs/ALPHA_SYSTEM_SUMMARY.md
@@ -23,7 +23,7 @@
    - Automatic increment tracking
    - Persistent across sessions
 
-### 🔧 The `ahk_alpha` Tool
+### 🔧 The `AHK_Alpha` Tool
 
 **Simple Commands:**
 - `{"action": "create"}` - Create alpha version
@@ -35,7 +35,7 @@
 
 **Built into Edit Tools:**
 ```javascript
-// In ahk_edit tool
+// In AHK_File_Edit tool
 try {
   // Edit operation
 } catch (error) {
@@ -121,8 +121,8 @@ Each alpha includes metadata:
 ## 🚀 Complete Integration
 
 The system is fully integrated with:
-- ✅ **ahk_edit** - Auto-tracks failures
-- ✅ **ahk_diff_edit** - Same tracking
+- ✅ **AHK_File_Edit** - Auto-tracks failures
+- ✅ **AHK_File_Edit_Diff** - Same tracking
 - ✅ **Active file system** - Auto-switches
 - ✅ **Settings system** - Can be enabled/disabled
 - ✅ **Error handling** - Graceful fallbacks

--- a/docs/ALPHA_VERSION_GUIDE.md
+++ b/docs/ALPHA_VERSION_GUIDE.md
@@ -26,12 +26,12 @@ Original: `MyScript.ahk`
 - Third alpha: `MyScript_a3.ahk`
 - And so on...
 
-## 🛠️ The `ahk_alpha` Tool
+## 🛠️ The `AHK_Alpha` Tool
 
 ### Create Alpha Version Manually
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "create"
   }
@@ -42,7 +42,7 @@ Creates `script_a1.ahk` and switches to it.
 ### Create with Reason
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "create",
     "reason": "Changing approach - original method not working"
@@ -53,7 +53,7 @@ Creates `script_a1.ahk` and switches to it.
 ### List All Alpha Versions
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "list"
   }
@@ -63,7 +63,7 @@ Creates `script_a1.ahk` and switches to it.
 ### Switch to Latest Alpha
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "latest"
   }
@@ -73,7 +73,7 @@ Creates `script_a1.ahk` and switches to it.
 ### Track Edit Failure
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "track_failure"
   }
@@ -84,7 +84,7 @@ Manually track a failure (auto-creates alpha after 3).
 ### Reset Version History
 ```json
 {
-  "tool": "ahk_alpha",
+  "tool": "AHK_Alpha",
   "arguments": {
     "action": "reset"
   }
@@ -105,7 +105,7 @@ Manually track a failure (auto-creates alpha after 3).
 ## 📊 Automatic Triggers
 
 ### Edit Tool Integration
-When `ahk_edit` or `ahk_diff_edit` fails:
+When `AHK_File_Edit` or `AHK_File_Edit_Diff` fails:
 1. Failure is tracked automatically
 2. After 3 failures → Alpha created
 3. Active file switches to alpha
@@ -144,7 +144,7 @@ After multiple failed attempts to fix a script:
 ```
 User: "Create an alpha version and try a different approach"
 
-Agent: Uses ahk_alpha to create test_a1.ahk
+Agent: Uses AHK_Alpha to create test_a1.ahk
        Implements new solution in alpha
        Original remains unchanged
 ```
@@ -202,25 +202,25 @@ Can be disabled with `"switchToAlpha": false`
 
 ### Create Alpha Now
 ```json
-{"tool": "ahk_alpha", "arguments": {"action": "create"}}
+{"tool": "AHK_Alpha", "arguments": {"action": "create"}}
 ```
 
 ### List Versions
 ```json
-{"tool": "ahk_alpha", "arguments": {"action": "list"}}
+{"tool": "AHK_Alpha", "arguments": {"action": "list"}}
 ```
 
 ### Reset Everything
 ```json
-{"tool": "ahk_alpha", "arguments": {"action": "reset"}}
+{"tool": "AHK_Alpha", "arguments": {"action": "reset"}}
 ```
 
 ## 🔄 Integration with Edit Tools
 
 The alpha system is fully integrated with:
-- `ahk_edit` - Tracks failures, auto-creates alphas
-- `ahk_diff_edit` - Same failure tracking
-- `ahk_file` - Works with alpha versions
+- `AHK_File_Edit` - Tracks failures, auto-creates alphas
+- `AHK_File_Edit_Diff` - Same failure tracking
+- `AHK_File_Active` - Works with alpha versions
 - Active file system - Auto-switches to alphas
 
 ## 💡 Tips

--- a/docs/CLAUDE_CODE_INSTALL.md
+++ b/docs/CLAUDE_CODE_INSTALL.md
@@ -84,23 +84,23 @@ If you need to manually configure, add this to your `mcp.json`:
 Once installed, Claude will have access to these AutoHotkey tools:
 
 ### Core Development Tools
-- `ahk_run` - Execute AutoHotkey scripts with window detection
-- `ahk_analyze` - Advanced code analysis
-- `ahk_diagnostics` - Error detection and validation
+- `AHK_Run` - Execute AutoHotkey scripts with window detection
+- `AHK_Analyze` - Advanced code analysis
+- `AHK_Diagnostics` - Error detection and validation
 
 ### Documentation & Context
-- `ahk_doc_search` - Search AutoHotkey documentation
-- `ahk_context_injector` - Auto-inject relevant context
-- `ahk_sampling_enhancer` - Enhance code samples
-- `ahk_summary` - Quick reference summaries
+- `AHK_Doc_Search` - Search AutoHotkey documentation
+- `AHK_Context_Injector` - Auto-inject relevant context
+- `AHK_Sampling_Enhancer` - Enhance code samples
+- `AHK_Summary` - Quick reference summaries
 
 ### Development Workflow
-- `ahk_prompts` - Access prompt templates
-- `ahk_debug_agent` - Debug assistance
-- `ahk_config` - Configuration management
-- `ahk_active_file` - Active file tracking
-- `ahk_recent_scripts` - Recent files tracking
-- `ahk_vscode_problems` - VS Code integration
+- `AHK_Prompts` - Access prompt templates
+- `AHK_Debug_Agent` - Debug assistance
+- `AHK_Config` - Configuration management
+- `AHK_Active_File` - Active file tracking
+- `AHK_File_Recent` - Recent files tracking
+- `AHK_VSCode_Problems` - VS Code integration
 
 ## Troubleshooting
 

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -68,40 +68,40 @@ node dist/index.js
 Once configured, Claude Code will have access to these AutoHotkey tools:
 
 ### 🔧 Core Tools
-- `ahk_run` - Run AutoHotkey scripts (with window detection!)
-- `ahk_analyze` - Analyze AutoHotkey code syntax
+- `AHK_Run` - Run AutoHotkey scripts (with window detection!)
+- `AHK_Analyze` - Analyze AutoHotkey code syntax
 - `ahk_complete` - Get code completion suggestions
-- `ahk_diagnostics` - Check for code issues
+- `AHK_Diagnostics` - Check for code issues
 
 ### 📝 Documentation Tools  
-- `ahk_doc_search` - Search AutoHotkey documentation
-- `ahk_summary` - Get quick reference summaries
-- `ahk_context_injector` - Auto-inject relevant docs
+- `AHK_Doc_Search` - Search AutoHotkey documentation
+- `AHK_Summary` - Get quick reference summaries
+- `AHK_Context_Injector` - Auto-inject relevant docs
 
 ### 🛠️ Development Tools
-- `ahk_debug_agent` - Debug assistance
-- `ahk_vscode_problems` - VS Code integration
-- `ahk_config` - Configuration management
-- `ahk_active_file` - Active file tracking
+- `AHK_Debug_Agent` - Debug assistance
+- `AHK_VSCode_Problems` - VS Code integration
+- `AHK_Config` - Configuration management
+- `AHK_Active_File` - Active file tracking
 
 ### 📋 Utility Tools
-- `ahk_recent_scripts` - Track recent scripts
-- `ahk_prompts` - Access prompt templates
-- `ahk_sampling_enhancer` - Enhance code samples
+- `AHK_File_Recent` - Track recent scripts
+- `AHK_Prompts` - Access prompt templates
+- `AHK_Sampling_Enhancer` - Enhance code samples
 
 ## Testing the Setup
 
 ### Basic Test
 ```bash
 # Start Claude Code and try:
-/ahk_summary
+/AHK_Summary
 ```
 
 ### Window Detection Test
 ```bash
 # In Claude Code, try running your test script:
 {
-  "tool": "ahk_run",
+  "tool": "AHK_Run",
   "args": {
     "mode": "run",
     "filePath": "C:\\Users\\uphol\\Documents\\Design\\Coding\\AHK\\!Running\\__Test-MCP.ahk",

--- a/docs/CLAUDE_DESKTOP_SETUP.md
+++ b/docs/CLAUDE_DESKTOP_SETUP.md
@@ -96,12 +96,12 @@ What AutoHotkey tools are available?
 
 **Test a simple tool:**
 ```
-Use ahk_config to show current settings
+Use AHK_Config to show current settings
 ```
 
 **Test file viewing:**
 ```
-Use ahk_file_view to show me the contents of C:\path\to\your\script.ahk
+Use AHK_File_View to show me the contents of C:\path\to\your\script.ahk
 ```
 
 ## Available Tools
@@ -109,28 +109,28 @@ Use ahk_file_view to show me the contents of C:\path\to\your\script.ahk
 Once configured, you'll have access to these AutoHotkey tools:
 
 ### 🔧 **File Management Tools**
-- `ahk_file_view` - View AutoHotkey files with syntax highlighting
-- `ahk_file_edit` - Edit files with search/replace operations
-- `ahk_file_edit_advanced` - Advanced file editing with diff patches
-- `ahk_file_edit_small` - Quick small edits
-- `ahk_file_active` - Manage active file context
-- `ahk_file_recent` - Track recently used files
+- `AHK_File_View` - View AutoHotkey files with syntax highlighting
+- `AHK_File_Edit` - Edit files with search/replace operations
+- `AHK_File_Edit_Advanced` - Advanced file editing with diff patches
+- `AHK_File_Edit_Small` - Quick small edits
+- `AHK_File_Active` - Manage active file context
+- `AHK_File_Recent` - Track recently used files
 
 ### 🏃 **Script Execution**
-- `ahk_run` - Execute AutoHotkey scripts with window detection
-- `ahk_debug_agent` - Debug assistance and error analysis
+- `AHK_Run` - Execute AutoHotkey scripts with window detection
+- `AHK_Debug_Agent` - Debug assistance and error analysis
 
 ### 📚 **Documentation & Analysis**
-- `ahk_doc_search` - Search AutoHotkey v2 documentation
-- `ahk_analyze` - Comprehensive code analysis
-- `ahk_diagnostics` - Syntax validation and error detection
-- `ahk_summary` - Quick reference summaries
+- `AHK_Doc_Search` - Search AutoHotkey v2 documentation
+- `AHK_Analyze` - Comprehensive code analysis
+- `AHK_Diagnostics` - Syntax validation and error detection
+- `AHK_Summary` - Quick reference summaries
 
 ### ⚙️ **Development Tools**
-- `ahk_config` - View and manage configuration
-- `ahk_settings` - Tool settings and preferences
-- `ahk_alpha` - Alpha versioning system for iterative development
-- `ahk_prompts` - Access prompt templates
+- `AHK_Config` - View and manage configuration
+- `AHK_Settings` - Tool settings and preferences
+- `AHK_Alpha` - Alpha versioning system for iterative development
+- `AHK_Prompts` - Access prompt templates
 
 ## Troubleshooting
 
@@ -160,12 +160,12 @@ This usually means the server is running but tools are failing:
    ```
 
 2. **Check tool names are correct:**
-   - Use `ahk_file_view` (not `AHK_File_View`)
+   - Use `AHK_File_View` (not `ahk_file_view`)
    - Names are case-sensitive
    - Use underscores, not hyphens
 
 3. **Test simple tools first:**
-   - Try `ahk_config` (no parameters needed)
+   - Try `AHK_Config` (no parameters needed)
    - Then try tools with parameters
 
 ### Path Issues
@@ -199,9 +199,9 @@ The server should start silently and wait for connections (this is normal behavi
 
 ## Next Steps
 
-1. **Test basic functionality** with simple tools like `ahk_config`
-2. **Try file operations** with `ahk_file_view` on existing `.ahk` files
-3. **Use documentation tools** like `ahk_doc_search` for development help
+1. **Test basic functionality** with simple tools like `AHK_Config`
+2. **Try file operations** with `AHK_File_View` on existing `.ahk` files
+3. **Use documentation tools** like `AHK_Doc_Search` for development help
 4. **Explore advanced features** like alpha versioning and file editing
 
 ## Support

--- a/docs/CODE_SPECIFICATION.md
+++ b/docs/CODE_SPECIFICATION.md
@@ -132,7 +132,7 @@ ahk-mcp/
 
 ### 3.1 MCP Tools
 
-#### ahk_diagnostics
+#### AHK_Diagnostics
 ```typescript
 interface AhkDiagnosticsArgs {
   code: string;                    // AutoHotkey v2 code to analyze
@@ -143,7 +143,7 @@ interface AhkDiagnosticsArgs {
 **Purpose**: Validates AutoHotkey v2 syntax and enforces coding standards
 **Returns**: Diagnostic messages grouped by severity with line/column info
 
-#### ahk_run
+#### AHK_Run
 ```typescript
 interface AhkRunArgs {
   mode: 'run' | 'watch';           // Execution mode
@@ -166,7 +166,7 @@ interface AhkRunArgs {
 **Purpose**: Execute AutoHotkey scripts with process management
 **Returns**: Execution status, PID, exit code, window detection results
 
-#### ahk_debug_agent
+#### AHK_Debug_Agent
 ```typescript
 interface AhkDebugAgentArgs {
   code?: string;                    // Code to debug
@@ -183,7 +183,7 @@ interface AhkDebugAgentArgs {
 **Purpose**: Advanced debugging assistance for AutoHotkey scripts
 **Returns**: Debug analysis, trace logs, fix suggestions
 
-#### ahk_doc_search
+#### AHK_Doc_Search
 ```typescript
 interface AhkDocSearchArgs {
   query: string;                    // Search query
@@ -195,7 +195,7 @@ interface AhkDocSearchArgs {
 **Purpose**: Search AutoHotkey v2 documentation
 **Returns**: Ranked search results with snippets
 
-#### ahk_analyze
+#### AHK_Analyze
 ```typescript
 interface AhkAnalyzeArgs {
   code: string;                     // Code to analyze
@@ -207,7 +207,7 @@ interface AhkAnalyzeArgs {
 **Purpose**: Deep code analysis with metrics and suggestions
 **Returns**: Analysis report with identified patterns and improvements
 
-#### ahk_context_injector
+#### AHK_Context_Injector
 ```typescript
 interface AhkContextInjectorArgs {
   prompt: string;                   // User prompt
@@ -218,7 +218,7 @@ interface AhkContextInjectorArgs {
 **Purpose**: Inject relevant AutoHotkey documentation into prompts
 **Returns**: Enhanced prompt with contextual documentation
 
-#### ahk_sampling_enhancer
+#### AHK_Sampling_Enhancer
 ```typescript
 interface AhkSamplingEnhancerArgs {
   request: string;                  // Original request
@@ -228,7 +228,7 @@ interface AhkSamplingEnhancerArgs {
 **Purpose**: Optimize prompts for MCP sampling
 **Returns**: Enhanced request with structured context
 
-#### ahk_vscode_problems
+#### AHK_VSCode_Problems
 ```typescript
 interface AhkVSCodeProblemsArgs {
   workspace?: string;               // Workspace path
@@ -238,7 +238,7 @@ interface AhkVSCodeProblemsArgs {
 **Purpose**: Read VS Code problems panel
 **Returns**: Current problems from VS Code
 
-#### ahk_recent_scripts
+#### AHK_File_Recent
 ```typescript
 interface AhkRecentArgs {
   limit?: number;                   // Number of scripts
@@ -248,7 +248,7 @@ interface AhkRecentArgs {
 **Purpose**: Track recently accessed AutoHotkey scripts
 **Returns**: List of recent scripts with metadata
 
-#### ahk_config
+#### AHK_Config
 ```typescript
 interface AhkConfigArgs {
   action: 'get' | 'set' | 'reset';
@@ -259,7 +259,7 @@ interface AhkConfigArgs {
 **Purpose**: Manage server configuration
 **Returns**: Configuration state
 
-#### ahk_active_file
+#### AHK_Active_File
 ```typescript
 interface AhkActiveFileArgs {
   action: 'get' | 'set';
@@ -269,12 +269,12 @@ interface AhkActiveFileArgs {
 **Purpose**: Track currently active AutoHotkey file
 **Returns**: Active file path
 
-#### ahk_summary
+#### AHK_Summary
 No arguments required
 **Purpose**: Provide summary of available AutoHotkey documentation
 **Returns**: Statistics and categories of loaded documentation
 
-#### ahk_prompts
+#### AHK_Prompts
 No arguments required
 **Purpose**: List available AutoHotkey expertise prompts
 **Returns**: Curated prompts for common tasks
@@ -586,7 +586,7 @@ const server = new AutoHotkeyMcpServer();
 const response = await server.handleRequest({
   jsonrpc: '2.0',
   method: 'tools/call',
-  params: { name: 'ahk_diagnostics', arguments: { code } }
+  params: { name: 'AHK_Diagnostics', arguments: { code } }
 });
 ```
 

--- a/docs/EDITING_SUMMARY.md
+++ b/docs/EDITING_SUMMARY.md
@@ -10,14 +10,14 @@ Created a comprehensive file editing system that works exactly like Claude's fil
 
 ### 🔧 Two Powerful Tools
 
-#### 1. `ahk_edit` - Swiss Army Knife Editor
+#### 1. `AHK_File_Edit` - Swiss Army Knife Editor
 - **Replace**: Text substitution with regex support
 - **Insert**: Add content at specific lines
 - **Delete**: Remove text or line ranges
 - **Append**: Add to end of file
 - **Prepend**: Add to beginning of file
 
-#### 2. `ahk_diff_edit` - Git-Style Diff Patches
+#### 2. `AHK_File_Edit_Diff` - Git-Style Diff Patches
 - **Unified Diff Parser**: Handles standard Git diff format
 - **Patch Application**: Applies diffs with validation
 - **Dry Run Mode**: Preview changes without applying
@@ -42,7 +42,7 @@ Created a comprehensive file editing system that works exactly like Claude's fil
 ```
 1. User: "C:\Scripts\test.ahk - change 'Hello' to 'Hi'"
 2. System: Sets activeFilePath = "C:\Scripts\test.ahk"
-3. Tool: ahk_edit with action "replace"
+3. Tool: AHK_File_Edit with action "replace"
 4. Result: File edited, backup created
 ```
 
@@ -50,7 +50,7 @@ Created a comprehensive file editing system that works exactly like Claude's fil
 ```
 1. User: Pastes file path and diff patch
 2. System: Detects path, sets as active
-3. Tool: ahk_diff_edit with unified diff
+3. Tool: AHK_File_Edit_Diff with unified diff
 4. Result: Patch applied with validation
 ```
 
@@ -58,7 +58,7 @@ Created a comprehensive file editing system that works exactly like Claude's fil
 ```
 1. File already active from previous operation
 2. User: "Insert error handling at line 5"
-3. Tool: ahk_edit with action "insert"
+3. Tool: AHK_File_Edit with action "insert"
 4. Result: New code added at specified line
 ```
 

--- a/docs/EDIT_TOOLS_GUIDE.md
+++ b/docs/EDIT_TOOLS_GUIDE.md
@@ -4,21 +4,21 @@ You now have powerful file editing capabilities that work with the `activeFilePa
 
 ## 🔧 Available Tools
 
-### 1. `ahk_edit` - Simple Edit Operations
+### 1. `AHK_File_Edit` - Simple Edit Operations
 For basic file editing operations like replace, insert, delete, append, prepend.
 
-### 2. `ahk_diff_edit` - Unified Diff Patches
+### 2. `AHK_File_Edit_Diff` - Unified Diff Patches
 For applying unified diff patches (like Git diffs) to files.
 
-### 3. `ahk_small_edit` - Targeted, Low-Token Updates
+### 3. `AHK_File_Edit_Small` - Targeted, Low-Token Updates
 Optimised for quick tweaks without sharing whole files. Supports regex or literal replacements and line-level inserts/deletes across one or many files. Optional `preview` shows a diff instead of writing.
 
-## 📝 ahk_edit Tool
+## 📝 AHK_File_Edit Tool
 
 ### Replace Text
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "replace",
     "search": "old text",
@@ -31,7 +31,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Insert at Line
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "insert",
     "line": 5,
@@ -43,7 +43,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Delete Text or Lines
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "delete",
     "search": "text to remove"
@@ -53,7 +53,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "delete",
     "startLine": 10,
@@ -65,7 +65,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Append to End
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "append",
     "content": "\n; Added at end"
@@ -76,7 +76,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Replace and Run Immediately
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "replace",
     "search": "MsgBox(\"Hello\")",
@@ -85,12 +85,12 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
   }
 }
 ```
-> Tip: Toggle the default behaviour via `ahk_settings` (`enable_auto_run` / `disable_auto_run`).
+> Tip: Toggle the default behaviour via `AHK_Settings` (`enable_auto_run` / `disable_auto_run`).
 
 ### Prepend to Beginning
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "prepend",
     "content": "#Requires AutoHotkey v2.0\n"
@@ -98,12 +98,12 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 }
 ```
 
-## ⚡ ahk_small_edit Quick Examples
+## ⚡ AHK_File_Edit_Small Quick Examples
 
 ### Regex Replace with Preview
 ```json
 {
-  "tool": "ahk_small_edit",
+  "tool": "AHK_File_Edit_Small",
   "arguments": {
     "action": "replace_regex",
     "file": "docs/PROJECT_STATUS.md",
@@ -117,7 +117,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Literal Replace Across Multiple Files
 ```json
 {
-  "tool": "ahk_small_edit",
+  "tool": "AHK_File_Edit_Small",
   "arguments": {
     "action": "replace_literal",
     "files": [
@@ -135,7 +135,7 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
 ### Insert After Specific Line
 ```json
 {
-  "tool": "ahk_small_edit",
+  "tool": "AHK_File_Edit_Small",
   "arguments": {
     "action": "line_insert_after",
     "file": "src/server.ts",
@@ -145,15 +145,15 @@ Optimised for quick tweaks without sharing whole files. Supports regex or litera
   }
 }
 ```
-> Tip: Enable persistent auto-run with `ahk_settings` → `enable_auto_run`.
+> Tip: Enable persistent auto-run with `AHK_Settings` → `enable_auto_run`.
 
-## 🔀 ahk_diff_edit Tool
+## 🔀 AHK_File_Edit_Diff Tool
 
 Apply unified diff patches like Git diffs:
 
 ```json
 {
-  "tool": "ahk_diff_edit",
+  "tool": "AHK_File_Edit_Diff",
   "arguments": {
     "diff": "--- original.ahk\n+++ modified.ahk\n@@ -1,3 +1,4 @@\n ; My Script\n+#Requires AutoHotkey v2.0\n \n MsgBox(\"Hello World\")",
     "dryRun": false
@@ -183,7 +183,7 @@ User: Add error handling to the active file
 
 Tool Call:
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "replace", 
     "search": "MsgBox(\"Hello\")",
@@ -195,14 +195,14 @@ Tool Call:
 ### Apply Diff and Run Right Away
 ```json
 {
-  "tool": "ahk_diff_edit",
+  "tool": "AHK_File_Edit_Diff",
   "arguments": {
     "diff": "--- script.ahk\n+++ script.ahk\n@@\n-MsgBox(\"Old\")\n+MsgBox(\"New\")",
     "runAfter": true
   }
 }
 ```
-> Tip: Toggle the default behaviour via `ahk_settings` if you want scripts to run automatically every time.
+> Tip: Toggle the default behaviour via `AHK_Settings` if you want scripts to run automatically every time.
 
 ### Example 2: Insert Function
 ```
@@ -210,7 +210,7 @@ User: Add a new function after line 10
 
 Tool Call:
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "insert",
     "line": 11,
@@ -233,7 +233,7 @@ User: Apply this diff patch:
 
 Tool Call:
 {
-  "tool": "ahk_diff_edit",
+  "tool": "AHK_File_Edit_Diff",
   "arguments": {
     "diff": "--- script.ahk\n+++ script.ahk\n@@ -1,3 +1,4 @@\n ; My AutoHotkey Script\n+#SingleInstance Force\n \n F1::MsgBox(\"F1 pressed\")"
   }
@@ -255,10 +255,10 @@ Both tools automatically work with the `activeFilePath`:
 Both tools create backup files (`.bak`) before making changes:
 - `script.ahk` → `script.ahk.bak`
 
-### Dry Run Mode (ahk_diff_edit)
+### Dry Run Mode (AHK_File_Edit_Diff)
 ```json
 {
-  "tool": "ahk_diff_edit",
+  "tool": "AHK_File_Edit_Diff",
   "arguments": {
     "diff": "...",
     "dryRun": true
@@ -301,7 +301,7 @@ Shows what would change without applying it.
 ### Regex Replace
 ```json
 {
-  "tool": "ahk_edit",
+  "tool": "AHK_File_Edit",
   "arguments": {
     "action": "replace",
     "search": "MsgBox\\(\"[^\"]*\"\\)",
@@ -315,7 +315,7 @@ Shows what would change without applying it.
 ### Range Deletion
 ```json
 {
-  "tool": "ahk_edit", 
+  "tool": "AHK_File_Edit", 
   "arguments": {
     "action": "delete",
     "startLine": 5,
@@ -326,7 +326,7 @@ Shows what would change without applying it.
 
 ## 💡 Tips
 
-1. **Use dryRun first** with `ahk_diff_edit` to preview changes
+1. **Use dryRun first** with `AHK_File_Edit_Diff` to preview changes
 2. **Backups are automatic** - disable with `"backup": false`
 3. **Line numbers are 1-based** for all operations
 4. **Regex patterns** use JavaScript regex syntax

--- a/docs/FILE_ACCESS_ANALYSIS.md
+++ b/docs/FILE_ACCESS_ANALYSIS.md
@@ -156,13 +156,13 @@ The `detectFilePaths()` function recognizes:
 ### **Manual File Management**
 ```typescript
 // Set active file explicitly
-ahk_file({ action: 'set', path: 'C:/Scripts/myapp.ahk' })
+AHK_File_Active({ action: 'set', path: 'C:/Scripts/myapp.ahk' })
 
 // Get current active file
-ahk_file({ action: 'get' })
+AHK_File_Active({ action: 'get' })
 
 // Detect files from text
-ahk_auto_file({ text: 'Edit the calculator.ahk file', autoSet: true })
+AHK_File_Detect({ text: 'Edit the calculator.ahk file', autoSet: true })
 ```
 
 ## 💡 **Best Practices**

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -12,8 +12,8 @@ From `.kiro/specs/autohotkey-mcp-server/requirements.md`:
 
 #### Acceptance Criteria ✅
 1. ✅ `ahk_complete` returns ranked completion candidates for valid cursor positions
-2. ✅ `ahk_diagnostics` returns diagnostic objects with line, character, message, severity
-3. ✅ `ahk_analyze` with `includeDocumentation=true` embeds inline documentation
+2. ✅ `AHK_Diagnostics` returns diagnostic objects with line, character, message, severity
+3. ✅ `AHK_Analyze` with `includeDocumentation=true` embeds inline documentation
 4. ✅ Unknown methods flagged with severity `error`
 5. ✅ Empty string completion returns empty array
 6. ✅ Invalid JSON requests return HTTP 400 with JSON error
@@ -164,11 +164,11 @@ When AutoHotkey-related keywords are detected, automatically activate tools:
 - Any .ahk file references or AutoHotkey syntax
 
 **Required Activation Sequence:**
-1. **Context Injection First** - `ahk_context_injector` with user's prompt
-2. **Code Analysis** - `ahk_analyze` for provided code
+1. **Context Injection First** - `AHK_Context_Injector` with user's prompt
+2. **Code Analysis** - `AHK_Analyze` for provided code
 3. **Completion Suggestions** - `ahk_complete` for code completion
-4. **Error Checking** - `ahk_diagnostics` for syntax validation
-5. **Template Retrieval** - `ahk_prompts` for relevant templates
+4. **Error Checking** - `AHK_Diagnostics` for syntax validation
+5. **Template Retrieval** - `AHK_Prompts` for relevant templates
 
 ## 🏗️ Architecture Overview
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -13,7 +13,7 @@ Current implementation status and feature completion tracking.
 - Resource management system
 
 **🆕 Script Execution with Window Detection** - Unique feature
-- Enhanced ahk_run tool with GUI detection
+- Enhanced AHK_Run tool with GUI detection
 - PowerShell-based window monitoring
 - Process management with PID tracking
 - Configurable timeouts and cleanup
@@ -81,23 +81,23 @@ Current implementation status and feature completion tracking.
 ## 🔧 Available MCP Tools
 
 ### Core Development Tools
-1. `ahk_run` - Execute scripts with window detection
-2. `ahk_analyze` - Advanced code analysis
-4. `ahk_diagnostics` - Error detection and validation
+1. `AHK_Run` - Execute scripts with window detection
+2. `AHK_Analyze` - Advanced code analysis
+4. `AHK_Diagnostics` - Error detection and validation
 
 ### Documentation & Context
-5. `ahk_doc_search` - Search AutoHotkey documentation
-6. `ahk_context_injector` - Auto-inject relevant context
-7. `ahk_sampling_enhancer` - Enhance code samples
-8. `ahk_summary` - Quick reference summaries
+5. `AHK_Doc_Search` - Search AutoHotkey documentation
+6. `AHK_Context_Injector` - Auto-inject relevant context
+7. `AHK_Sampling_Enhancer` - Enhance code samples
+8. `AHK_Summary` - Quick reference summaries
 
 ### Development Workflow
-9. `ahk_prompts` - Access prompt templates
-10. `ahk_debug_agent` - Debug assistance
-11. `ahk_config` - Configuration management
-12. `ahk_active_file` - Active file tracking
-13. `ahk_recent_scripts` - Recent files tracking
-14. `ahk_vscode_problems` - VS Code integration
+9. `AHK_Prompts` - Access prompt templates
+10. `AHK_Debug_Agent` - Debug assistance
+11. `AHK_Config` - Configuration management
+12. `AHK_Active_File` - Active file tracking
+13. `AHK_File_Recent` - Recent files tracking
+14. `AHK_VSCode_Problems` - VS Code integration
 
 ### System Integration
 15. Various MCP resources for live data and templates

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -16,22 +16,22 @@
 
 #### Quick Edit
 ```json
-{"tool": "ahk_edit", "arguments": {"action": "replace", "search": "old text", "content": "new text"}}
+{"tool": "AHK_File_Edit", "arguments": {"action": "replace", "search": "old text", "content": "new text"}}
 ```
 
 #### Apply Git Diff
 ```json
-{"tool": "ahk_diff_edit", "arguments": {"diff": "--- file.ahk\n+++ file.ahk\n@@ -1,3 +1,4 @@\n code"}}
+{"tool": "AHK_File_Edit_Diff", "arguments": {"diff": "--- file.ahk\n+++ file.ahk\n@@ -1,3 +1,4 @@\n code"}}
 ```
 
 #### Create Alpha Version
 ```json
-{"tool": "ahk_alpha", "arguments": {"action": "create"}}
+{"tool": "AHK_Alpha", "arguments": {"action": "create"}}
 ```
 
 #### Manage Settings
 ```json
-{"tool": "ahk_settings", "arguments": {"action": "disable_editing"}}
+{"tool": "AHK_Settings", "arguments": {"action": "disable_editing"}}
 ```
 
 ### 📋 Common Workflows
@@ -39,7 +39,7 @@
 #### 1. Quick Text Replace
 ```
 User: "Change all 'Hello' to 'Hi' in the active file"
-Tool: ahk_edit with action "replace", search "Hello", content "Hi", all true
+Tool: AHK_File_Edit with action "replace", search "Hello", content "Hi", all true
 ```
 
 #### 2. Multi-line Input
@@ -72,22 +72,22 @@ Edit fails → Edit fails → Edit fails
 
 ```json
 // Read-only mode
-{"tool": "ahk_settings", "arguments": {"action": "disable_editing"}}
+{"tool": "AHK_Settings", "arguments": {"action": "disable_editing"}}
 
 // Full editing mode  
-{"tool": "ahk_settings", "arguments": {"action": "enable_editing"}}
+{"tool": "AHK_Settings", "arguments": {"action": "enable_editing"}}
 
 // Check what's enabled
-{"tool": "ahk_settings", "arguments": {"action": "get"}}
+{"tool": "AHK_Settings", "arguments": {"action": "get"}}
 ```
 
 ### 🎯 Token Efficiency
 
-**Most Efficient**: `ahk_edit` (20-30 tokens per operation)
-**Less Efficient**: `ahk_diff_edit` (100-200 tokens per operation)
+**Most Efficient**: `AHK_File_Edit` (20-30 tokens per operation)
+**Less Efficient**: `AHK_File_Edit_Diff` (100-200 tokens per operation)
 
-**Use `ahk_edit` for**: Simple replacements, line insertions, quick changes
-**Use `ahk_diff_edit` for**: Complex multi-location changes, when you have existing diffs
+**Use `AHK_File_Edit` for**: Simple replacements, line insertions, quick changes
+**Use `AHK_File_Edit_Diff` for**: Complex multi-location changes, when you have existing diffs
 
 ### 📁 File Locations
 
@@ -103,8 +103,8 @@ Edit fails → Edit fails → Edit fails
 - Check path format (quotes for spaces)
 
 **Tool disabled?**
-- Run: `{"tool": "ahk_settings", "arguments": {"action": "get"}}`
-- Enable with: `{"tool": "ahk_settings", "arguments": {"action": "enable_editing"}}`
+- Run: `{"tool": "AHK_Settings", "arguments": {"action": "get"}}`
+- Enable with: `{"tool": "AHK_Settings", "arguments": {"action": "enable_editing"}}`
 
 **Edit failed?**
 - Check file permissions
@@ -114,7 +114,7 @@ Edit fails → Edit fails → Edit fails
 ### 🎯 Best Practices
 
 1. **Let auto-detection work** - Just mention file paths naturally
-2. **Use simple edits** - `ahk_edit` is more token-efficient
+2. **Use simple edits** - `AHK_File_Edit` is more token-efficient
 3. **Enable alpha versioning** - Great for experimental changes
 4. **Check settings first** - Know what tools are available
 5. **Backup before big changes** - Use dry-run mode for previews

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -11,8 +11,8 @@
 - **Persistent File Tracking**: Active file survives server restarts
 
 #### 🆕 Advanced Editing Tools
-- **`ahk_edit`**: Comprehensive text editing with replace, insert, delete, append, prepend operations
-- **`ahk_diff_edit`**: Apply unified diff patches (Git-style diffs) with validation and dry-run mode
+- **`AHK_File_Edit`**: Comprehensive text editing with replace, insert, delete, append, prepend operations
+- **`AHK_File_Edit_Diff`**: Apply unified diff patches (Git-style diffs) with validation and dry-run mode
 - **Regex Support**: Full regex pattern matching for search and replace operations
 - **Automatic Backups**: Creates `.bak` files before any modification
 - **Token-Efficient**: Minimal token usage compared to diff-based approaches
@@ -32,23 +32,23 @@
 
 ### New Tools Added
 
-1. **`ahk_file`** - Active file management (get, set, detect, clear)
-2. **`ahk_edit`** - Text editing operations with regex support
-3. **`ahk_diff_edit`** - Apply unified diff patches
-4. **`ahk_alpha`** - Alpha version creation and management
-5. **`ahk_settings`** - Tool configuration and feature toggles
-6. **`ahk_auto_file`** - Automatic file path detection from text
-7. **`ahk_process_request`** - Multi-line input processing
+1. **`AHK_File_Active`** - Active file management (get, set, detect, clear)
+2. **`AHK_File_Edit`** - Text editing operations with regex support
+3. **`AHK_File_Edit_Diff`** - Apply unified diff patches
+4. **`AHK_Alpha`** - Alpha version creation and management
+5. **`AHK_Settings`** - Tool configuration and feature toggles
+6. **`AHK_File_Detect`** - Automatic file path detection from text
+7. **`AHK_Process_Request`** - Multi-line input processing
 
 ### Enhanced Existing Tools
 
-#### `ahk_run`
+#### `AHK_Run`
 - **Active File Integration**: Uses active file when no path specified
 - **Enhanced Process Management**: Better PID tracking and cleanup
 - **Window Detection**: Verify GUI script window creation with timing
 - **Error Handling**: Improved error messages with suggestions
 
-#### `ahk_diagnostics` & `ahk_analyze`
+#### `AHK_Diagnostics` & `AHK_Analyze`
 - **Auto File Detection**: Automatically detect file paths in code input
 - **Active File Support**: Work with active file when no code provided
 
@@ -59,13 +59,13 @@
 
 ### Configuration & Settings
 
-#### Tool Settings (`ahk_settings`)
+#### Tool Settings (`AHK_Settings`)
 ```json
 // Disable all file editing tools
 {"action": "disable_editing"}
 
 // Enable specific tool
-{"action": "enable_tool", "tool": "ahk_edit"}
+{"action": "enable_tool", "tool": "AHK_File_Edit"}
 
 // Configure global settings
 {"action": "set", "settings": {"alwaysBackup": true, "maxFileSize": 5242880}}
@@ -87,7 +87,7 @@
 ```
 User: "C:\Scripts\test.ahk - fix the syntax errors"
 → File automatically detected and set as active
-→ ahk_diagnostics runs on the file
+→ AHK_Diagnostics runs on the file
 → Issues identified and fixed
 ```
 
@@ -125,7 +125,7 @@ User provides Git diff patch:
 - **Error-First Design**: Robust error handling with graceful fallbacks
 
 #### Performance
-- **Token Efficiency**: `ahk_edit` uses 6x fewer tokens than diff-based editing
+- **Token Efficiency**: `AHK_File_Edit` uses 6x fewer tokens than diff-based editing
 - **Smart Caching**: File content caching and validation
 - **Lazy Loading**: Documentation loaded on-demand
 - **Process Management**: Efficient AutoHotkey process tracking

--- a/docs/SETTINGS_GUIDE.md
+++ b/docs/SETTINGS_GUIDE.md
@@ -4,12 +4,12 @@
 
 You now have a comprehensive settings system that allows you to **enable or disable individual tools** and control various features of the MCP server.
 
-## 🎛️ The `ahk_settings` Tool
+## 🎛️ The `AHK_Settings` Tool
 
 ### Get Current Settings
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "get"
   }
@@ -19,7 +19,7 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Disable File Editing Tools
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "disable_editing"
   }
@@ -29,7 +29,7 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Enable File Editing Tools
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "enable_editing"
   }
@@ -39,7 +39,7 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Enable Auto Run After Edits
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "enable_auto_run"
   }
@@ -49,7 +49,7 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Disable Auto Run After Edits
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "disable_auto_run"
   }
@@ -59,10 +59,10 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Disable a Specific Tool
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "disable_tool",
-    "tool": "ahk_edit"
+    "tool": "AHK_File_Edit"
   }
 }
 ```
@@ -70,10 +70,10 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ### Enable a Specific Tool
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "enable_tool",
-    "tool": "ahk_edit"
+    "tool": "AHK_File_Edit"
   }
 }
 ```
@@ -83,8 +83,8 @@ You now have a comprehensive settings system that allows you to **enable or disa
 | Action | Description | Example |
 |--------|-------------|---------|
 | `get` | Show current settings | View all tool states |
-| `enable_tool` | Enable a specific tool | `"tool": "ahk_edit"` |
-| `disable_tool` | Disable a specific tool | `"tool": "ahk_file"` |
+| `enable_tool` | Enable a specific tool | `"tool": "AHK_File_Edit"` |
+| `disable_tool` | Disable a specific tool | `"tool": "AHK_File_Active"` |
 | `enable_editing` | Enable ALL file editing tools | Enables 7 tools at once |
 | `disable_editing` | Disable ALL file editing tools | Disables 7 tools at once |
 | `enable_auto_run` | Enable automatic run after edits | Persists the `runAfter` preference |
@@ -97,27 +97,27 @@ You now have a comprehensive settings system that allows you to **enable or disa
 ## 📦 Tool Groups
 
 ### File Editing Tools (Can be disabled)
-- `ahk_edit` - Text editing operations
-- `ahk_diff_edit` - Diff patch application
-- `ahk_file` - Active file management
-- `ahk_auto_file` - Automatic file detection
-- `ahk_active_file` - Legacy active file tool
-- `ahk_process_request` - Multi-line request processing
-- `ahk_small_edit` - Lightweight line/pattern edits
+- `AHK_File_Edit` - Text editing operations
+- `AHK_File_Edit_Diff` - Diff patch application
+- `AHK_File_Active` - Active file management
+- `AHK_File_Detect` - Automatic file detection
+- `AHK_Active_File` - Legacy active file tool
+- `AHK_Process_Request` - Multi-line request processing
+- `AHK_File_Edit_Small` - Lightweight line/pattern edits
 
 ### Core Tools (Always enabled)
-- `ahk_diagnostics` - Code validation
-- `ahk_analyze` - Code analysis
-- `ahk_run` - Script execution
-- `ahk_summary` - Documentation summary
-- `ahk_settings` - This settings tool
+- `AHK_Diagnostics` - Code validation
+- `AHK_Analyze` - Code analysis
+- `AHK_Run` - Script execution
+- `AHK_Summary` - Documentation summary
+- `AHK_Settings` - This settings tool
 
 ## 🛡️ Global Settings
 
 ### Configure Global Options
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "set",
     "settings": {
@@ -151,13 +151,13 @@ Settings are persisted in:
 ```json
 {
   "enabledTools": {
-    "ahk_edit": true,
-    "ahk_diff_edit": true,
-    "ahk_file": true,
-    "ahk_auto_file": true,
-    "ahk_active_file": true,
-    "ahk_process_request": true,
-    "ahk_small_edit": true
+    "AHK_File_Edit": true,
+    "AHK_File_Edit_Diff": true,
+    "AHK_File_Active": true,
+    "AHK_File_Detect": true,
+    "AHK_Active_File": true,
+    "AHK_Process_Request": true,
+    "AHK_File_Edit_Small": true
   },
   "allowFileEditing": true,
   "allowFileDetection": true,
@@ -175,7 +175,7 @@ Settings are persisted in:
 Disable all file editing but keep analysis:
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "disable_editing"
   }
@@ -186,7 +186,7 @@ Disable all file editing but keep analysis:
 Only core tools, no file operations:
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "disable_all"
   }
@@ -197,7 +197,7 @@ Only core tools, no file operations:
 Require explicit file paths:
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "set",
     "settings": {
@@ -212,7 +212,7 @@ Require explicit file paths:
 Always backup, restrict to .ahk only:
 ```json
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "set",
     "settings": {
@@ -228,14 +228,14 @@ Always backup, restrict to .ahk only:
 
 When you try to use a disabled tool, you'll get:
 ```
-⚠️ Tool 'ahk_edit' is currently disabled.
+⚠️ Tool 'AHK_File_Edit' is currently disabled.
 
-To enable it, use the 'ahk_settings' tool:
+To enable it, use the 'AHK_Settings' tool:
 {
-  "tool": "ahk_settings",
+  "tool": "AHK_Settings",
   "arguments": {
     "action": "enable_tool",
-    "tool": "ahk_edit"
+    "tool": "AHK_File_Edit"
   }
 }
 ```
@@ -251,22 +251,22 @@ export AHK_MCP_SETTINGS_PATH=/custom/path/settings.json
 
 ### Check What's Enabled
 ```json
-{"tool": "ahk_settings", "arguments": {"action": "get"}}
+{"tool": "AHK_Settings", "arguments": {"action": "get"}}
 ```
 
 ### Turn Off File Editing
 ```json
-{"tool": "ahk_settings", "arguments": {"action": "disable_editing"}}
+{"tool": "AHK_Settings", "arguments": {"action": "disable_editing"}}
 ```
 
 ### Turn On File Editing
 ```json
-{"tool": "ahk_settings", "arguments": {"action": "enable_editing"}}
+{"tool": "AHK_Settings", "arguments": {"action": "enable_editing"}}
 ```
 
 ### Reset Everything
 ```json
-{"tool": "ahk_settings", "arguments": {"action": "reset"}}
+{"tool": "AHK_Settings", "arguments": {"action": "reset"}}
 ```
 
 ## 🎯 Benefits
@@ -279,7 +279,7 @@ export AHK_MCP_SETTINGS_PATH=/custom/path/settings.json
 
 ## Notes
 
-- Core tools (`ahk_diagnostics`, `ahk_analyze`, `ahk_run`, `ahk_summary`) **cannot be disabled**
-- The `ahk_settings` tool itself **cannot be disabled**
+- Core tools (`AHK_Diagnostics`, `AHK_Analyze`, `AHK_Run`, `AHK_Summary`) **cannot be disabled**
+- The `AHK_Settings` tool itself **cannot be disabled**
 - Settings are loaded on server start and saved immediately on change
 - Disabled tools return helpful messages explaining how to re-enable them

--- a/docs/SIMPLE_ACTIVE_FILE.md
+++ b/docs/SIMPLE_ACTIVE_FILE.md
@@ -21,10 +21,10 @@ activeFile.activeFilePath  // This is THE variable
 ### The Variable is Set When:
 
 - **Any tool receives input** containing a .ahk file path
-- User uses `ahk_file` tool to explicitly set it
-- User runs `ahk_run` with a file path
-- User provides code to `ahk_diagnostics` that contains a path
-- User mentions a path in `ahk_analyze` input
+- User uses `AHK_File_Active` tool to explicitly set it
+- User runs `AHK_Run` with a file path
+- User provides code to `AHK_Diagnostics` that contains a path
+- User mentions a path in `AHK_Analyze` input
 - **Basically: ANY TIME a .ahk path appears ANYWHERE**
 
 ## Usage Examples
@@ -61,7 +61,7 @@ Then the tool runs with that file
 
 ## The Tools
 
-### Primary Tool: `ahk_file`
+### Primary Tool: `AHK_File_Active`
 Simple management of the shared variable:
 - `action: "get"` - Show current active file
 - `action: "set"` - Set the active file
@@ -70,9 +70,9 @@ Simple management of the shared variable:
 
 ### All Other Tools
 **AUTOMATICALLY** detect and use the variable:
-- `ahk_run` - Uses active file if no path provided
-- `ahk_diagnostics` - Auto-detects paths in code
-- `ahk_analyze` - Auto-detects paths in code
+- `AHK_Run` - Uses active file if no path provided
+- `AHK_Diagnostics` - Auto-detects paths in code
+- `AHK_Analyze` - Auto-detects paths in code
 - Every other tool - Same behavior
 
 ## Technical Details

--- a/docs/TOOL_RENAMING_PLAN.md
+++ b/docs/TOOL_RENAMING_PLAN.md
@@ -6,15 +6,15 @@
 
 | Current File Name | Current Tool Name | → | New File Name | New Tool Name | Purpose |
 |------------------|-------------------|---|---------------|---------------|---------|
-| `ahk-file.ts` | `ahk_file` | → | `ahk-file-active.ts` | `ahk_file_active` | Set/get active file context |
-| `ahk-auto-file.ts` | `ahk_auto_file` | → | `ahk-file-detect.ts` | `ahk_file_detect` | Auto-detect files from text |
-| `ahk-recent.ts` | `ahk_recent_scripts` | → | `ahk-file-recent.ts` | `ahk_file_recent` | Recent file history |
-| `ahk-active-file.ts` | `ahk_active_file` | → | (REMOVE - duplicate) | (merge into ahk_file_active) | Duplicate functionality |
-| (NEW) | - | → | `ahk-file-view.ts` | `ahk_file_view` | View files (already created) |
-| `ahk-edit.ts` | `ahk_edit` | → | `ahk-file-edit.ts` | `ahk_file_edit` | Edit active file |
-| `ahk-small-edit.ts` | `ahk_small_edit` | → | `ahk-file-edit-small.ts` | `ahk_file_edit_small` | Small targeted edits |
-| `ahk-diff-edit.ts` | `ahk_diff_edit` | → | `ahk-file-edit-diff.ts` | `ahk_file_edit_diff` | Diff-based editing |
-| `ahk-file-editor.ts` | `ahk_file_editor` | → | `ahk-file-edit-advanced.ts` | `ahk_file_edit_advanced` | Advanced editing features |
+| `ahk-file.ts` | `AHK_File_Active` | → | `ahk-file-active.ts` | `AHK_File_Active` | Set/get active file context |
+| `ahk-auto-file.ts` | `AHK_File_Detect` | → | `ahk-file-detect.ts` | `AHK_File_Detect` | Auto-detect files from text |
+| `ahk-recent.ts` | `AHK_File_Recent` | → | `ahk-file-recent.ts` | `AHK_File_Recent` | Recent file history |
+| `ahk-active-file.ts` | `AHK_Active_File` | → | (REMOVE - duplicate) | (merge into AHK_File_Active) | Duplicate functionality |
+| (NEW) | - | → | `ahk-file-view.ts` | `AHK_File_View` | View files (already created) |
+| `ahk-edit.ts` | `AHK_File_Edit` | → | `ahk-file-edit.ts` | `AHK_File_Edit` | Edit active file |
+| `ahk-small-edit.ts` | `AHK_File_Edit_Small` | → | `ahk-file-edit-small.ts` | `AHK_File_Edit_Small` | Small targeted edits |
+| `ahk-diff-edit.ts` | `AHK_File_Edit_Diff` | → | `ahk-file-edit-diff.ts` | `AHK_File_Edit_Diff` | Diff-based editing |
+| `ahk-file-editor.ts` | `AHK_File_Edit_Advanced` | → | `ahk-file-edit-advanced.ts` | `AHK_File_Edit_Advanced` | Advanced editing features |
 
 **Chain Benefits**: All file operations start with `ahk-file-` making them easy to discover and understand.
 
@@ -24,12 +24,12 @@
 
 | Current File Name | Current Tool Name | → | New File Name | New Tool Name | Purpose |
 |------------------|-------------------|---|---------------|---------------|---------|
-| `ahk-analyze.ts` | `ahk_analyze` | → | `ahk-analyze-code.ts` | `ahk_analyze_code` | Code analysis & documentation |
-| `ahk-diagnostics.ts` | `ahk_diagnostics` | → | `ahk-analyze-diagnostics.ts` | `ahk_analyze_diagnostics` | Error detection |
-| `ahk-lsp.ts` | `ahk_lsp` | → | `ahk-analyze-lsp.ts` | `ahk_analyze_lsp` | LSP-style analysis & fixes |
-| `ahk-summary.ts` | `ahk_summary` | → | `ahk-analyze-summary.ts` | `ahk_analyze_summary` | Project summaries |
-| `ahk-vscode-problems.ts` | `ahk_vscode_problems` | → | `ahk-analyze-vscode.ts` | `ahk_analyze_vscode` | VS Code integration |
-| `ahk-analyze-unified.ts` | `ahk_analyze_unified` | → | `ahk-analyze-complete.ts` | `ahk_analyze_complete` | Complete analysis pipeline |
+| `ahk-analyze.ts` | `AHK_Analyze` | → | `ahk-analyze-code.ts` | `AHK_Analyze` | Code analysis & documentation |
+| `ahk-diagnostics.ts` | `AHK_Diagnostics` | → | `ahk-analyze-diagnostics.ts` | `AHK_Diagnostics` | Error detection |
+| `ahk-lsp.ts` | `AHK_LSP` | → | `ahk-analyze-lsp.ts` | `AHK_LSP` | LSP-style analysis & fixes |
+| `ahk-summary.ts` | `AHK_Summary` | → | `ahk-analyze-summary.ts` | `AHK_Summary` | Project summaries |
+| `ahk-vscode-problems.ts` | `AHK_VSCode_Problems` | → | `ahk-analyze-vscode.ts` | `AHK_VSCode_Problems` | VS Code integration |
+| `ahk-analyze-unified.ts` | `AHK_Analyze_Unified` | → | `ahk-analyze-complete.ts` | `AHK_Analyze_Unified` | Complete analysis pipeline |
 
 **Chain Benefits**: All analysis tools grouped together, clear progression from basic to advanced.
 
@@ -39,9 +39,9 @@
 
 | Current File Name | Current Tool Name | → | New File Name | New Tool Name | Purpose |
 |------------------|-------------------|---|---------------|---------------|---------|
-| `ahk-run.ts` | `ahk_run` | → | `ahk-run-script.ts` | `ahk_run_script` | Execute AutoHotkey scripts |
-| `ahk-debug-agent.ts` | `ahk_debug_agent` | → | `ahk-run-debug.ts` | `ahk_run_debug` | Debug execution |
-| `ahk-process-request.ts` | `ahk_process_request` | → | `ahk-run-process.ts` | `ahk_run_process` | Process management |
+| `ahk-run.ts` | `AHK_Run` | → | `ahk-run-script.ts` | `AHK_Run` | Execute AutoHotkey scripts |
+| `ahk-debug-agent.ts` | `AHK_Debug_Agent` | → | `ahk-run-debug.ts` | `AHK_Debug_Agent` | Debug execution |
+| `ahk-process-request.ts` | `AHK_Process_Request` | → | `ahk-run-process.ts` | `AHK_Process_Request` | Process management |
 
 **Chain Benefits**: Clear execution workflow from running to debugging.
 
@@ -51,11 +51,11 @@
 
 | Current File Name | Current Tool Name | → | New File Name | New Tool Name | Purpose |
 |------------------|-------------------|---|---------------|---------------|---------|
-| `ahk-doc-search.ts` | `ahk_doc_search` | → | `ahk-docs-search.ts` | `ahk_docs_search` | Search documentation |
-| `ahk-prompts.ts` | `ahk_prompts` | → | `ahk-docs-prompts.ts` | `ahk_docs_prompts` | Prompt catalog |
-| `ahk-context-injector.ts` | `ahk_context_injector` | → | `ahk-docs-context.ts` | `ahk_docs_context` | Context injection |
-| `module-prompt-manager.ts` | `module_prompt_manager` | → | `ahk-docs-modules.ts` | `ahk_docs_modules` | Module management |
-| `ahk-sampling-enhancer.ts` | `ahk_sampling_enhancer` | → | `ahk-docs-samples.ts` | `ahk_docs_samples` | Code samples |
+| `ahk-doc-search.ts` | `AHK_Doc_Search` | → | `ahk-docs-search.ts` | `AHK_Doc_Search` | Search documentation |
+| `ahk-prompts.ts` | `AHK_Prompts` | → | `ahk-docs-prompts.ts` | `AHK_Prompts` | Prompt catalog |
+| `ahk-context-injector.ts` | `AHK_Context_Injector` | → | `ahk-docs-context.ts` | `AHK_Context_Injector` | Context injection |
+| `module-prompt-manager.ts` | `module_prompt_manager` | → | `ahk-docs-modules.ts` | `module_prompt_manager` | Module management |
+| `ahk-sampling-enhancer.ts` | `AHK_Sampling_Enhancer` | → | `ahk-docs-samples.ts` | `AHK_Sampling_Enhancer` | Code samples |
 
 **Chain Benefits**: All documentation and knowledge tools in one place.
 
@@ -65,9 +65,9 @@
 
 | Current File Name | Current Tool Name | → | New File Name | New Tool Name | Purpose |
 |------------------|-------------------|---|---------------|---------------|---------|
-| `ahk-config.ts` | `ahk_config` | → | `ahk-system-config.ts` | `ahk_system_config` | Configuration management |
-| `ahk-settings.ts` | `ahk_settings` | → | `ahk-system-settings.ts` | `ahk_system_settings` | MCP settings |
-| `ahk-alpha.ts` | `ahk_alpha` | → | `ahk-system-alpha.ts` | `ahk_system_alpha` | Alpha/experimental features |
+| `ahk-config.ts` | `AHK_Config` | → | `ahk-system-config.ts` | `AHK_Config` | Configuration management |
+| `ahk-settings.ts` | `AHK_Settings` | → | `ahk-system-settings.ts` | `AHK_Settings` | MCP settings |
+| `ahk-alpha.ts` | `AHK_Alpha` | → | `ahk-system-alpha.ts` | `AHK_Alpha` | Alpha/experimental features |
 
 **Chain Benefits**: System-level tools clearly separated from user-facing tools.
 
@@ -77,9 +77,9 @@
 
 ### **Step 1: Backward Compatibility**
 ```typescript
-// In server.ts, register both old and new names
-'ahk_file': ahkFileActiveTool,      // Old name (deprecated)
-'ahk_file_active': ahkFileActiveTool // New name
+// In server.ts, register both old and new names during transition
+'ahk_file_active': ahkFileActiveTool,      // Old name (deprecated)
+'AHK_File_Active': ahkFileActiveTool // New name
 ```
 
 ### **Step 2: Deprecation Warnings**
@@ -109,7 +109,7 @@ if (toolName.startsWith('ahk_') && !toolName.includes('_')) {
 
 3. **Tool name format**:
    - Hyphens in files: `ahk-file-edit.ts`
-   - Underscores in tools: `ahk_file_edit`
+   - Underscores in tools: `AHK_File_Edit`
    - Is this consistent enough?
 
 4. **Priority**:

--- a/src/core/tool-settings.ts
+++ b/src/core/tool-settings.ts
@@ -10,14 +10,16 @@ import logger from '../logger.js';
 export interface ToolSettings {
   // Core tool settings
   enabledTools: {
-    ahk_edit: boolean;
-    ahk_diff_edit: boolean;
-    ahk_file: boolean;
-    ahk_auto_file: boolean;
-    ahk_active_file: boolean;
-    ahk_process_request: boolean;
-    ahk_alpha: boolean;
-    ahk_small_edit: boolean;
+    AHK_File_Edit: boolean;
+    AHK_File_Edit_Diff: boolean;
+    AHK_File_Edit_Advanced: boolean;
+    AHK_File_Edit_Small: boolean;
+    AHK_File_View: boolean;
+    AHK_File_Detect: boolean;
+    AHK_File_Active: boolean;
+    AHK_Active_File: boolean;
+    AHK_Process_Request: boolean;
+    AHK_Alpha: boolean;
     // Other tools can be added here
     [key: string]: boolean;
   };
@@ -76,28 +78,33 @@ class ToolSettingsManager {
     return {
       enabledTools: {
         // File editing tools - can be disabled
-        ahk_edit: true,
-        ahk_diff_edit: true,
-        ahk_file: true,
-        ahk_auto_file: true,
-        ahk_active_file: true,
-        ahk_process_request: true,
-        ahk_alpha: true,
-        ahk_small_edit: true,
-        
+        AHK_File_Edit: true,
+        AHK_File_Edit_Diff: true,
+        AHK_File_Edit_Advanced: true,
+        AHK_File_Edit_Small: true,
+        AHK_File_View: true,
+        AHK_File_Detect: true,
+        AHK_File_Active: true,
+        AHK_Active_File: true,
+        AHK_Process_Request: true,
+        AHK_Alpha: true,
+
         // Core tools - always enabled
-        ahk_diagnostics: true,
-        ahk_analyze: true,
-        ahk_run: true,
-        ahk_summary: true,
-        ahk_prompts: true,
-        ahk_debug_agent: true,
-        ahk_doc_search: true,
-        ahk_context_injector: true,
-        ahk_sampling_enhancer: true,
-        ahk_vscode_problems: true,
-        ahk_recent_scripts: true,
-        ahk_config: true
+        AHK_Diagnostics: true,
+        AHK_Analyze: true,
+        AHK_Analyze_Unified: true,
+        AHK_Run: true,
+        AHK_Summary: true,
+        AHK_Prompts: true,
+        AHK_Debug_Agent: true,
+        AHK_Doc_Search: true,
+        AHK_Context_Injector: true,
+        AHK_Sampling_Enhancer: true,
+        AHK_VSCode_Problems: true,
+        AHK_File_Recent: true,
+        AHK_Config: true,
+        AHK_LSP: true,
+        AHK_Settings: true
       },
       
       // Global settings
@@ -215,7 +222,17 @@ class ToolSettingsManager {
    * Enable/disable file editing tools as a group
    */
   setFileEditingTools(enabled: boolean): void {
-    const fileTools = ['ahk_edit', 'ahk_diff_edit', 'ahk_file', 'ahk_auto_file', 'ahk_active_file', 'ahk_process_request', 'ahk_alpha', 'ahk_small_edit'];
+    const fileTools = [
+      'AHK_File_Edit',
+      'AHK_File_Edit_Diff',
+      'AHK_File_Edit_Advanced',
+      'AHK_File_Edit_Small',
+      'AHK_File_View',
+      'AHK_File_Detect',
+      'AHK_File_Active',
+      'AHK_Process_Request',
+      'AHK_Alpha'
+    ];
     for (const tool of fileTools) {
       this.settings.enabledTools[tool] = enabled;
     }
@@ -240,11 +257,14 @@ class ToolSettingsManager {
    */
   getDisabledMessage(toolName: string): string {
     if (!this.isToolEnabled(toolName)) {
-      return `⚠️ Tool '${toolName}' is currently disabled.\n\nTo enable it, use the 'ahk_settings' tool:\n\`\`\`json\n{\n  "tool": "ahk_settings",\n  "arguments": {\n    "action": "enable_tool",\n    "tool": "${toolName}"\n  }\n}\n\`\`\``;
+      return `⚠️ Tool '${toolName}' is currently disabled.\n\nTo enable it, use the 'AHK_Settings' tool:\n\`\`\`json\n{\n  "tool": "AHK_Settings",\n  "arguments": {\n    "action": "enable_tool",\n    "tool": "${toolName}"\n  }\n}\n\`\`\``;
     }
     
-    if (!this.settings.allowFileEditing && ['ahk_edit', 'ahk_diff_edit', 'ahk_small_edit'].includes(toolName)) {
-      return `⚠️ File editing is currently disabled.\n\nTo enable it, use the 'ahk_settings' tool:\n\`\`\`json\n{\n  "tool": "ahk_settings",\n  "arguments": {\n    "action": "enable_editing"\n  }\n}\n\`\`\``;
+    if (
+      !this.settings.allowFileEditing &&
+      ['AHK_File_Edit', 'AHK_File_Edit_Diff', 'AHK_File_Edit_Small', 'AHK_File_Edit_Advanced'].includes(toolName)
+    ) {
+      return `⚠️ File editing is currently disabled.\n\nTo enable it, use the 'AHK_Settings' tool:\n\`\`\`json\n{\n  "tool": "AHK_Settings",\n  "arguments": {\n    "action": "enable_editing"\n  }\n}\n\`\`\``;
     }
     
     return '';

--- a/src/http-server.ts.bak
+++ b/src/http-server.ts.bak
@@ -42,9 +42,9 @@ class AutoHotkeyHttpServer {
           tools: [
             // This would need to be implemented properly in your server
             // For now, return a basic structure
-            { name: 'ahk_diagnostics', description: 'AutoHotkey diagnostics tool' },
-            { name: 'ahk_analyze', description: 'AutoHotkey analysis tool' },
-            { name: 'ahk_prompts', description: 'AutoHotkey prompts tool' }
+            { name: 'AHK_Diagnostics', description: 'AutoHotkey diagnostics tool' },
+            { name: 'AHK_Analyze', description: 'AutoHotkey analysis tool' },
+            { name: 'AHK_Prompts', description: 'AutoHotkey prompts tool' }
           ]
         };
         res.json(tools);

--- a/src/server.ts
+++ b/src/server.ts
@@ -220,99 +220,99 @@ export class AutoHotkeyMcpServer {
         let result: any;
 
         switch (name) {
-          case 'ahk_file_edit_advanced':
+          case 'AHK_File_Edit_Advanced':
             result = await this.ahkFileEditorToolInstance.execute(args as any);
             break;
 
-          case 'ahk_diagnostics':
+          case 'AHK_Diagnostics':
             result = await this.ahkDiagnosticsToolInstance.execute(args as any);
             break;
 
-          case 'ahk_summary':
+          case 'AHK_Summary':
             result = await this.ahkSummaryToolInstance.execute();
             break;
 
-          case 'ahk_prompts':
+          case 'AHK_Prompts':
             result = await this.ahkPromptsToolInstance.execute();
             break;
 
-          case 'ahk_analyze':
+          case 'AHK_Analyze':
             result = await this.ahkAnalyzeToolInstance.execute(args as any);
             break;
 
-          case 'ahk_context_injector':
+          case 'AHK_Context_Injector':
             result = await this.ahkContextInjectorToolInstance.execute(args as any);
             break;
 
-          case 'ahk_sampling_enhancer':
+          case 'AHK_Sampling_Enhancer':
             result = await this.ahkSamplingEnhancerToolInstance.execute(args as any);
             break;
 
-          case 'ahk_debug_agent':
+          case 'AHK_Debug_Agent':
             result = await this.ahkDebugAgentToolInstance.execute(args as any);
             break;
 
-          case 'ahk_doc_search':
+          case 'AHK_Doc_Search':
             result = await this.ahkDocSearchToolInstance.execute(args as any);
             break;
 
-          case 'ahk_run':
+          case 'AHK_Run':
             result = await this.ahkRunToolInstance.execute(args as any);
             break;
 
-          case 'ahk_vscode_problems':
+          case 'AHK_VSCode_Problems':
             result = await this.ahkVSCodeProblemsToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_recent':
+          case 'AHK_File_Recent':
             result = await this.ahkRecentToolInstance.execute(args as any);
             break;
 
-          case 'ahk_config':
+          case 'AHK_Config':
             result = await this.ahkConfigToolInstance.execute(args as any);
             break;
 
-          case 'ahk_active_file':
+          case 'AHK_Active_File':
             result = await this.ahkActiveFileToolInstance.execute(args as any);
             break;
 
-          case 'ahk_lsp':
+          case 'AHK_LSP':
             result = await this.ahkLspToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_view':
+          case 'AHK_File_View':
             result = await this.ahkFileViewToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_detect':
+          case 'AHK_File_Detect':
             result = await this.ahkAutoFileToolInstance.execute(args as any);
             break;
 
-          case 'ahk_process_request':
+          case 'AHK_Process_Request':
             result = await this.ahkProcessRequestToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_active':
+          case 'AHK_File_Active':
             result = await this.ahkFileToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_edit':
+          case 'AHK_File_Edit':
             result = await this.ahkEditToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_edit_diff':
+          case 'AHK_File_Edit_Diff':
             result = await this.ahkDiffEditToolInstance.execute(args as any);
             break;
 
-          case 'ahk_settings':
+          case 'AHK_Settings':
             result = await this.ahkSettingsToolInstance.execute(args as any);
             break;
 
-          case 'ahk_file_edit_small':
+          case 'AHK_File_Edit_Small':
             result = await this.ahkSmallEditToolInstance.execute(args as any);
             break;
 
-          case 'ahk_alpha':
+          case 'AHK_Alpha':
             result = await this.ahkAlphaToolInstance.execute(args as any);
             break;
 
@@ -591,7 +591,7 @@ export class AutoHotkeyMcpServer {
             {
               uri,
               mimeType: 'text/markdown',
-              text: '## 🎯 AutoHotkey Context Available\n\nUse the `ahk_context_injector` tool to analyze your prompts and get relevant AutoHotkey documentation automatically injected.'
+              text: '## 🎯 AutoHotkey Context Available\n\nUse the `AHK_Context_Injector` tool to analyze your prompts and get relevant AutoHotkey documentation automatically injected.'
             }
           ]
         };

--- a/src/tools/ahk-active-file.ts
+++ b/src/tools/ahk-active-file.ts
@@ -9,7 +9,7 @@ export const AhkActiveFileArgsSchema = z.object({
 });
 
 export const ahkActiveFileToolDefinition = {
-  name: 'ahk_active_file',
+  name: 'AHK_Active_File',
   description: `Ahk active file
 Get or set the active AHK file path used as a default when invoking tools.`,
   inputSchema: {
@@ -41,7 +41,7 @@ export class AhkActiveFileTool {
       const updated = loadConfig();
       return { content: [ { type: 'text', text: 'Active file updated.' }, { type: 'text', text: JSON.stringify({ activeFile: updated.activeFile || null }, null, 2) } ] };
     } catch (error) {
-      logger.error('Error in ahk_active_file tool:', error);
+      logger.error('Error in AHK_Active_File tool:', error);
       return { content: [{ type: 'text', text: `❌ Error: ${error instanceof Error ? error.message : String(error)}` }] };
     }
   }

--- a/src/tools/ahk-analyze-code.ts
+++ b/src/tools/ahk-analyze-code.ts
@@ -11,7 +11,7 @@ export const AhkAnalyzeArgsSchema = z.object({
 });
 
 export const ahkAnalyzeToolDefinition = {
-  name: 'ahk_analyze',
+  name: 'AHK_Analyze',
   description: `Ahk analyze
 Analyzes AutoHotkey v2 scripts and provides contextual information about functions, variables, classes, and other elements used in the code.`,
   inputSchema: {
@@ -209,12 +209,12 @@ export class AhkAnalyzeTool {
 
       if (includeDocumentation) {
         report += '\n## 📚 Documentation Support\n';
-        report += 'Leverage the `ahk_doc_search` tool or ChatGPT `search`/`fetch` helpers to pull detailed reference material for the functions and directives found in this script.\n';
+        report += 'Leverage the `AHK_Doc_Search` tool or ChatGPT `search`/`fetch` helpers to pull detailed reference material for the functions and directives found in this script.\n';
       }
 
       if (includeUsageExamples) {
         report += '\n## 🧪 Usage Examples\n';
-        report += 'Invoke `ahk_sampling_enhancer` to generate runnable usage samples for the highlighted APIs and hotkeys.\n';
+        report += 'Invoke `AHK_Sampling_Enhancer` to generate runnable usage samples for the highlighted APIs and hotkeys.\n';
       }
 
       return {

--- a/src/tools/ahk-analyze-complete.ts
+++ b/src/tools/ahk-analyze-complete.ts
@@ -32,7 +32,7 @@ export const AhkAnalyzeUnifiedArgsSchema = z.object({
 });
 
 export const ahkAnalyzeUnifiedToolDefinition = {
-  name: 'ahk_analyze_unified',
+  name: 'AHK_Analyze_Unified',
   description: `Unified AutoHotkey Code Analysis & Improvement Tool
 
 Combines analysis, diagnostics, auto-fixing, and VS Code integration into one powerful tool.

--- a/src/tools/ahk-analyze-diagnostics.ts
+++ b/src/tools/ahk-analyze-diagnostics.ts
@@ -14,7 +14,7 @@ export const AhkDiagnosticsArgsSchema = z.object({
 });
 
 export const ahkDiagnosticsToolDefinition = {
-  name: 'ahk_diagnostics',
+  name: 'AHK_Diagnostics',
   description: `Ahk diagnostics
 Validates AutoHotkey v2 code syntax and enforces coding standards with detailed error reporting`,
   inputSchema: {
@@ -81,7 +81,7 @@ export class AhkDiagnosticsTool {
         ]
       };
     } catch (error) {
-      logger.error('Error in ahk_diagnostics tool:', error);
+      logger.error('Error in AHK_Diagnostics tool:', error);
       
       return {
         content: [

--- a/src/tools/ahk-analyze-lsp.ts
+++ b/src/tools/ahk-analyze-lsp.ts
@@ -15,7 +15,7 @@ export const AhkLspArgsSchema = z.object({
 });
 
 export const ahkLspToolDefinition = {
-  name: 'ahk_lsp',
+  name: 'AHK_LSP',
   description: `AutoHotkey LSP-style Code Analysis & Auto-Fix
 
 Acts like a Language Server Protocol (LSP) for AutoHotkey v2:

--- a/src/tools/ahk-analyze-summary.ts
+++ b/src/tools/ahk-analyze-summary.ts
@@ -6,7 +6,7 @@ import logger from '../logger.js';
 export const AhkSummaryArgsSchema = z.object({});
 
 export const ahkSummaryToolDefinition = {
-  name: 'ahk_summary',
+  name: 'AHK_Summary',
   description: `Ahk summary
 Returns a summary of built-in variables, classes, and coding standards for AutoHotkey v2.`,
   inputSchema: {

--- a/src/tools/ahk-analyze-vscode.ts
+++ b/src/tools/ahk-analyze-vscode.ts
@@ -19,7 +19,7 @@ export const AhkVSCodeProblemsArgsSchema = z.object({
 });
 
 export const ahkVSCodeProblemsToolDefinition = {
-  name: 'ahk_vscode_problems',
+  name: 'AHK_VSCode_Problems',
   description: `Ahk vscode problems
 Reads a VS Code Problems list (from file or provided JSON) and summarizes AutoHotkey LSP diagnostics.`,
   inputSchema: {
@@ -121,7 +121,7 @@ export class AhkVSCodeProblemsTool {
       const text = this.formatSummary(filtered, limit);
       return { content: [{ type: 'text', text }] };
     } catch (error) {
-      logger.error('Error in ahk_vscode_problems tool:', error);
+      logger.error('Error in AHK_VSCode_Problems tool:', error);
       return {
         content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
 

--- a/src/tools/ahk-docs-context.ts
+++ b/src/tools/ahk-docs-context.ts
@@ -13,7 +13,7 @@ export const AhkContextInjectorArgsSchema = z.object({
 });
 
 export const ahkContextInjectorToolDefinition = {
-  name: 'ahk_context_injector',
+  name: 'AHK_Context_Injector',
   description: `Ahk context injector
 Analyzes user prompts and LLM thinking to automatically inject relevant AutoHotkey v2 documentation context.`,
   inputSchema: {
@@ -87,11 +87,11 @@ export class AhkContextInjectorTool {
     this.keywordMap.set('toggle', ['if', 'else', 'Boolean']);
 
     // File editing triggers
-    this.keywordMap.set('edit', ['ahk_file_editor', 'ahk_edit', 'ahk_file']);
-    this.keywordMap.set('modify', ['ahk_file_editor', 'ahk_edit', 'ahk_file']);
-    this.keywordMap.set('change', ['ahk_file_editor', 'ahk_edit', 'ahk_file']);
-    this.keywordMap.set('update', ['ahk_file_editor', 'ahk_edit', 'ahk_file']);
-    this.keywordMap.set('fix', ['ahk_file_editor', 'ahk_edit', 'ahk_diagnostics']);
+    this.keywordMap.set('edit', ['AHK_File_Edit_Advanced', 'AHK_File_Edit', 'AHK_File_Active']);
+    this.keywordMap.set('modify', ['AHK_File_Edit_Advanced', 'AHK_File_Edit', 'AHK_File_Active']);
+    this.keywordMap.set('change', ['AHK_File_Edit_Advanced', 'AHK_File_Edit', 'AHK_File_Active']);
+    this.keywordMap.set('update', ['AHK_File_Edit_Advanced', 'AHK_File_Edit', 'AHK_File_Active']);
+    this.keywordMap.set('fix', ['AHK_File_Edit_Advanced', 'AHK_File_Edit', 'AHK_Diagnostics']);
   }
 
   private initializeModuleKeywordMap(): void {
@@ -288,8 +288,8 @@ export class AhkContextInjectorTool {
 
         if (hasFilePath) {
           generalContext += '**🚨 FILE PATH DETECTED - USE FILE EDITING TOOLS!**\n\n' +
-            '**Primary Action:** Use `ahk_file_editor` tool to set the file as active and get editing guidance\n' +
-            '**Follow-up:** Use `ahk_edit` for direct file modifications\n' +
+            '**Primary Action:** Use `AHK_File_Edit_Advanced` tool to set the file as active and get editing guidance\n' +
+            '**Follow-up:** Use `AHK_File_Edit` for direct file modifications\n' +
             '**Important:** Always edit the actual file instead of generating code blocks\n\n';
         }
 
@@ -307,10 +307,10 @@ export class AhkContextInjectorTool {
 
         if (hasFilePath) {
           generalContext += '\n\n**🔧 Available File Editing Tools:**\n' +
-            '- `ahk_file_editor` - Primary tool for file operations\n' +
-            '- `ahk_edit` - Direct text editing (replace, insert, delete)\n' +
-            '- `ahk_file` - Manage active file settings\n' +
-            '- `ahk_run` - Test the edited script';
+            '- `AHK_File_Edit_Advanced` - Primary tool for file operations\n' +
+            '- `AHK_File_Edit` - Direct text editing (replace, insert, delete)\n' +
+            '- `AHK_File_Active` - Manage active file settings\n' +
+            '- `AHK_Run` - Test the edited script';
         }
 
         return {
@@ -335,9 +335,9 @@ export class AhkContextInjectorTool {
         finalText += '## 🎯 FILE EDITING DETECTED\n\n';
         finalText += '**🚨 IMPORTANT: Use file editing tools instead of generating code blocks!**\n\n';
         finalText += '**Recommended Workflow:**\n';
-        finalText += '1. Use `ahk_file_editor` to set the target file and get editing guidance\n';
-        finalText += '2. Use `ahk_edit` for specific text modifications\n';
-        finalText += '3. Use `ahk_run` to test the changes\n\n';
+        finalText += '1. Use `AHK_File_Edit_Advanced` to set the target file and get editing guidance\n';
+        finalText += '2. Use `AHK_File_Edit` for specific text modifications\n';
+        finalText += '3. Use `AHK_Run` to test the changes\n\n';
         finalText += '---\n\n';
       }
 

--- a/src/tools/ahk-docs-prompts.ts
+++ b/src/tools/ahk-docs-prompts.ts
@@ -18,7 +18,7 @@ export interface PromptTemplate {
 export const AhkPromptsArgsSchema = z.object({});
 
 export const ahkPromptsToolDefinition = {
-  name: "ahk_prompts",
+  name: "AHK_Prompts",
   description: `AHK Prompts
 Returns a set of built-in AHK v2 prompt templates for code generation and learning.`,
   inputSchema: {
@@ -31,7 +31,7 @@ Returns a set of built-in AHK v2 prompt templates for code generation and learni
 export const DEFAULT_PROMPTS: PromptTemplate[] = [
   {
     title: "Auto Context",
-    body: "Jumpstart conversations by immediately calling `ahk_context_injector`.\n- Paste the user request into `userPrompt`\n- Leave `contextType` as `auto` unless you know the specific category\n- Set `includeModuleInstructions` to `true` to pull module expertise\n\nAfter the tool returns contextual snippets, review them before generating code.",
+    body: "Jumpstart conversations by immediately calling `AHK_Context_Injector`.\n- Paste the user request into `userPrompt`\n- Leave `contextType` as `auto` unless you know the specific category\n- Set `includeModuleInstructions` to `true` to pull module expertise\n\nAfter the tool returns contextual snippets, review them before generating code.",
     source: "default",
     slug: getPromptSlug("Auto Context")
   },

--- a/src/tools/ahk-docs-samples.ts
+++ b/src/tools/ahk-docs-samples.ts
@@ -15,7 +15,7 @@ export const AhkSamplingEnhancerArgsSchema = z.object({
 });
 
 export const ahkSamplingEnhancerToolDefinition = {
-  name: 'ahk_sampling_enhancer',
+  name: 'AHK_Sampling_Enhancer',
   description: `Ahk sampling enhancer
 Automatically enhances prompts with AutoHotkey v2 context using MCP sampling standards when AutoHotkey-related content is detected.`,
   inputSchema: {

--- a/src/tools/ahk-docs-search.ts
+++ b/src/tools/ahk-docs-search.ts
@@ -10,7 +10,7 @@ export const AhkDocSearchArgsSchema = z.object({
 });
 
 export const ahkDocSearchToolDefinition = {
-  name: 'ahk_doc_search',
+  name: 'AHK_Doc_Search',
   description: `Ahk doc search
 Full-text search across AutoHotkey v2 docs using FlexSearch (functions, variables, classes, methods).`,
   inputSchema: {
@@ -152,7 +152,7 @@ export class AhkDocSearchTool {
         content: [{ type: 'text', text: `Results for "${query}" (${category}):\n\n${lines.join('\n')}` }]
       };
     } catch (error) {
-      logger.error('Error in ahk_doc_search tool:', error);
+      logger.error('Error in AHK_Doc_Search tool:', error);
       return {
         content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
 

--- a/src/tools/ahk-file-active.ts
+++ b/src/tools/ahk-file-active.ts
@@ -11,7 +11,7 @@ export const AhkFileArgsSchema = z.object({
 });
 
 export const ahkFileToolDefinition = {
-  name: 'ahk_file_active',
+  name: 'AHK_File_Active',
   description: `Ahk file
 DETECT AND SET ACTIVE FILE FOR EDITING - Use this immediately when user mentions any .ahk file path. This enables all other editing tools to work on the specified file. Essential first step before any file modifications.`,
   inputSchema: {
@@ -39,7 +39,7 @@ export class AhkFileTool {
   async execute(args: z.infer<typeof AhkFileArgsSchema>): Promise<any> {
     try {
       // Check if tool is enabled
-      const availability = checkToolAvailability('ahk_file');
+      const availability = checkToolAvailability('AHK_File_Active');
       if (!availability.enabled) {
         return {
           content: [{ type: 'text', text: availability.message || 'Tool is disabled' }]
@@ -74,7 +74,7 @@ export class AhkFileTool {
             response += '❌ No active file set\n\n';
             response += 'Set one by:\n';
             response += '• Mentioning a .ahk file path in any message\n';
-            response += '• Using `ahk_file` with action "set"\n';
+            response += '• Using `AHK_File_Active` with action "set"\n';
             response += '• Running any tool with a file path\n';
           }
           
@@ -146,7 +146,7 @@ export class AhkFileTool {
       }
       
     } catch (error) {
-      logger.error('Error in ahk_file tool:', error);
+      logger.error('Error in AHK_File_Active tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-file-detect.ts
+++ b/src/tools/ahk-file-detect.ts
@@ -16,7 +16,7 @@ export const AhkAutoFileArgsSchema = z.object({
 });
 
 export const ahkAutoFileToolDefinition = {
-  name: 'ahk_file_detect',
+  name: 'AHK_File_Detect',
   description: `Ahk auto file
 Automatically detect and set active AutoHotkey file from user text`,
   inputSchema: {
@@ -136,7 +136,7 @@ export class AhkAutoFileTool {
       };
       
     } catch (error) {
-      logger.error('Error in ahk_auto_file tool:', error);
+      logger.error('Error in AHK_File_Detect tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-file-edit-advanced.ts
+++ b/src/tools/ahk-file-edit-advanced.ts
@@ -10,7 +10,7 @@ export const AhkFileEditorArgsSchema = z.object({
 });
 
 export const ahkFileEditorToolDefinition = {
-  name: 'ahk_file_edit_advanced',
+  name: 'AHK_File_Edit_Advanced',
   description: `Ahk file editor
 🎯 PRIMARY FILE EDITING TOOL - Use this IMMEDIATELY when user mentions a .ahk file path and wants to modify it. This tool automatically detects the file, sets it active, and helps determine the best editing approach. ALWAYS use this instead of generating code blocks when a file path is provided.`,
   inputSchema: {
@@ -92,9 +92,9 @@ export class AhkFileEditorTool {
 
       response += `**✅ File is now active and ready for editing!**\n\n`;
       response += `**Next: Use these tools to make the changes:**\n`;
-      response += `• \`ahk_edit\` - For direct text replacements, insertions, deletions (set 'runAfter': true to run immediately)\n`;
-      response += `• \`ahk_diff_edit\` - For complex multi-location changes\n`;
-      response += `• \`ahk_run\` - To test the changes after editing\n`;
+      response += `• \`AHK_File_Edit\` - For direct text replacements, insertions, deletions (set 'runAfter': true to run immediately)\n`;
+      response += `• \`AHK_File_Edit_Diff\` - For complex multi-location changes\n`;
+      response += `• \`AHK_Run\` - To test the changes after editing\n`;
 
       return {
         content: [{
@@ -104,7 +104,7 @@ export class AhkFileEditorTool {
       };
 
     } catch (error) {
-      logger.error('Error in ahk_file_editor:', error);
+      logger.error('Error in AHK_File_Edit_Advanced:', error);
       return {
         content: [{
           type: 'text',
@@ -123,35 +123,35 @@ export class AhkFileEditorTool {
 
     // Detect the type of editing needed
     if (lowerChanges.includes('replace') || lowerChanges.includes('change') || lowerChanges.includes('update')) {
-      guidance += `• **Text Replacement** - Use \`ahk_edit\` with action "replace"\n`;
+      guidance += `• **Text Replacement** - Use \`AHK_File_Edit\` with action "replace"\n`;
       guidance += `  Example: Replace specific text, variables, or function names\n`;
     }
 
     if (lowerChanges.includes('add') || lowerChanges.includes('insert') || lowerChanges.includes('new')) {
-      guidance += `• **Add Content** - Use \`ahk_edit\` with action "insert" or "append"\n`;
+      guidance += `• **Add Content** - Use \`AHK_File_Edit\` with action "insert" or "append"\n`;
       guidance += `  Example: Add new functions, variables, or hotkeys\n`;
     }
 
     if (lowerChanges.includes('remove') || lowerChanges.includes('delete') || lowerChanges.includes('fix')) {
-      guidance += `• **Remove/Fix Content** - Use \`ahk_edit\` with action "delete"\n`;
+      guidance += `• **Remove/Fix Content** - Use \`AHK_File_Edit\` with action "delete"\n`;
       guidance += `  Example: Remove broken code, fix syntax errors\n`;
     }
 
     if (lowerChanges.includes('syntax') || lowerChanges.includes('error') || lowerChanges.includes('debug')) {
-      guidance += `• **Syntax Fixes** - Run \`ahk_diagnostics\` first to identify issues\n`;
-      guidance += `  Then use \`ahk_edit\` to fix each problem\n`;
+      guidance += `• **Syntax Fixes** - Run \`AHK_Diagnostics\` first to identify issues\n`;
+      guidance += `  Then use \`AHK_File_Edit\` to fix each problem\n`;
     }
 
     if (lowerChanges.includes('refactor') || lowerChanges.includes('restructure') || lowerChanges.includes('organize')) {
-      guidance += `• **Major Changes** - Consider using \`ahk_diff_edit\` for complex restructuring\n`;
-      guidance += `  Or break into multiple smaller \`ahk_edit\` operations\n`;
+      guidance += `• **Major Changes** - Consider using \`AHK_File_Edit_Diff\` for complex restructuring\n`;
+      guidance += `  Or break into multiple smaller \`AHK_File_Edit\` operations\n`;
     }
 
     // Default guidance if nothing specific detected
     if (!guidance) {
-      guidance = `• **General Editing** - Use \`ahk_edit\` for most modifications\n`;
+      guidance = `• **General Editing** - Use \`AHK_File_Edit\` for most modifications\n`;
       guidance += `• **Text Replacement** - Most efficient for simple changes\n`;
-      guidance += `• **Complex Changes** - Use \`ahk_diff_edit\` for multi-location updates\n`;
+      guidance += `• **Complex Changes** - Use \`AHK_File_Edit_Diff\` for multi-location updates\n`;
     }
 
     return guidance;

--- a/src/tools/ahk-file-edit-diff.ts
+++ b/src/tools/ahk-file-edit-diff.ts
@@ -14,7 +14,7 @@ export const AhkDiffEditArgsSchema = z.object({
 });
 
 export const ahkDiffEditToolDefinition = {
-  name: 'ahk_file_edit_diff',
+  name: 'AHK_File_Edit_Diff',
   description: `Ahk diff edit
 Apply unified diff patches to edit AutoHotkey files (similar to Claude filesystem MCP)`,
   inputSchema: {
@@ -232,7 +232,7 @@ export class AhkDiffEditTool {
   async execute(args: z.infer<typeof AhkDiffEditArgsSchema>): Promise<any> {
     try {
       // Check if tool is enabled
-      const availability = checkToolAvailability('ahk_diff_edit');
+      const availability = checkToolAvailability('AHK_File_Edit_Diff');
       if (!availability.enabled) {
         return {
           content: [{ type: 'text', text: availability.message || 'Tool is disabled' }]
@@ -245,7 +245,7 @@ export class AhkDiffEditTool {
       // Get the target file
       const targetFile = filePath || activeFile.getActiveFile();
       if (!targetFile) {
-        throw new Error('No file specified and no active file set. Use ahk_file to set an active file first.');
+        throw new Error('No file specified and no active file set. Use AHK_File_Active to set an active file first.');
       }
 
       // Ensure it's an .ahk file
@@ -348,7 +348,7 @@ export class AhkDiffEditTool {
       };
       
     } catch (error) {
-      logger.error('Error in ahk_diff_edit tool:', error);
+      logger.error('Error in AHK_File_Edit_Diff tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-file-edit-small.ts
+++ b/src/tools/ahk-file-edit-small.ts
@@ -40,7 +40,7 @@ export const AhkSmallEditArgsSchema = z.object({
 });
 
 export const ahkSmallEditToolDefinition = {
-  name: 'ahk_file_edit_small',
+  name: 'AHK_File_Edit_Small',
   description: `AHK Small Edit
 Token-efficient file editing for simple replacements and line edits. Supports regex or literal replacements and line targeting with optional preview.`,
   inputSchema: {
@@ -144,7 +144,7 @@ export class AhkSmallEditTool {
 
   async execute(rawArgs: z.infer<typeof AhkSmallEditArgsSchema>): Promise<ToolResponse> {
     try {
-      const availability = checkToolAvailability('ahk_small_edit');
+      const availability = checkToolAvailability('AHK_File_Edit_Small');
       if (!availability.enabled) {
         return {
           content: [{ type: 'text', text: availability.message || 'Tool is disabled' }],
@@ -252,7 +252,7 @@ export class AhkSmallEditTool {
         content: [{ type: 'text', text: reports.join('\n\n') }],
       };
     } catch (error) {
-      logger.error('Error in ahk_small_edit tool:', error);
+      logger.error('Error in AHK_File_Edit_Small tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-file-edit.ts
+++ b/src/tools/ahk-file-edit.ts
@@ -22,7 +22,7 @@ export const AhkEditArgsSchema = z.object({
 });
 
 export const ahkEditToolDefinition = {
-  name: 'ahk_file_edit',
+  name: 'AHK_File_Edit',
   description: `AHK Edit
 DIRECTLY EDIT AND MODIFY AUTOHOTKEY FILES ON DISK - Use this tool when the user provides a file path and wants to make changes to the actual file. Always prefer this over generating code blocks when a file path is mentioned. Supports replace, insert, delete, append, prepend operations.`,
   inputSchema: {
@@ -178,7 +178,7 @@ export class AhkEditTool {
     
     try {
       // Check if tool is enabled
-      const availability = checkToolAvailability('ahk_edit');
+      const availability = checkToolAvailability('AHK_File_Edit');
       if (!availability.enabled) {
         return {
           content: [{ type: 'text', text: availability.message || 'Tool is disabled' }]
@@ -192,7 +192,7 @@ export class AhkEditTool {
       // Get the target file
       const targetFile = filePath || activeFile.getActiveFile();
       if (!targetFile) {
-        throw new Error('No file specified and no active file set. Use ahk_file to set an active file first.');
+        throw new Error('No file specified and no active file set. Use AHK_File_Active to set an active file first.');
       }
 
       // Ensure it's an .ahk file
@@ -343,7 +343,7 @@ export class AhkEditTool {
       };
       
     } catch (error) {
-      logger.error('Error in ahk_edit tool:', error);
+      logger.error('Error in AHK_File_Edit tool:', error);
       
       // Check if we should create an alpha version due to failures
       const targetFile = validatedArgs?.filePath || activeFile.getActiveFile();

--- a/src/tools/ahk-file-recent.ts
+++ b/src/tools/ahk-file-recent.ts
@@ -13,7 +13,7 @@ export const AhkRecentArgsSchema = z.object({
 });
 
 export const ahkRecentToolDefinition = {
-  name: 'ahk_file_recent',
+  name: 'AHK_File_Recent',
   description: `Ahk recent scripts
 List the most recent AutoHotkey scripts from configured directories. Supports overriding A_ScriptDir.`,
   inputSchema: {
@@ -115,7 +115,7 @@ export class AhkRecentTool {
         ],
       };
     } catch (error) {
-      logger.error('Error in ahk_recent_scripts tool:', error);
+      logger.error('Error in AHK_File_Recent tool:', error);
       return {
         content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }]
       };

--- a/src/tools/ahk-file-view.ts
+++ b/src/tools/ahk-file-view.ts
@@ -19,7 +19,7 @@ export const AhkFileViewArgsSchema = z.object({
 });
 
 export const ahkFileViewToolDefinition = {
-  name: 'ahk_file_view',
+  name: 'AHK_File_View',
   description: `📖 AutoHotkey File Viewer (File Chain)
 
 Premier file viewing tool in the ahk-file-* chain. Provides structured, intelligent viewing of AutoHotkey files with multiple display modes.

--- a/src/tools/ahk-run-debug.ts
+++ b/src/tools/ahk-run-debug.ts
@@ -358,7 +358,7 @@ export const AhkDebugAgentArgsSchema = z.object({
 });
 
 export const ahkDebugAgentToolDefinition = {
-  name: 'ahk_debug_agent',
+  name: 'AHK_Debug_Agent',
   description: `Ahk debug agent
 Starts a TCP listener for AutoHotkey /Debug and optionally proxies to a real debug adapter while capturing traffic.`,
   inputSchema: {
@@ -496,7 +496,7 @@ export class AhkDebugAgentTool {
 
       return { content: [{ type: 'text', text: '❌ Unsupported mode' }] };
     } catch (error) {
-      logger.error('Error in ahk_debug_agent tool:', error);
+      logger.error('Error in AHK_Debug_Agent tool:', error);
       return {
         content: [
           { type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }

--- a/src/tools/ahk-run-process.ts
+++ b/src/tools/ahk-run-process.ts
@@ -14,7 +14,7 @@ export const AhkProcessRequestArgsSchema = z.object({
 });
 
 export const ahkProcessRequestToolDefinition = {
-  name: 'ahk_process_request',
+  name: 'AHK_Process_Request',
   description: `Ahk process request
 Process user requests that contain file paths and instructions for AutoHotkey scripts`,
   inputSchema: {
@@ -240,7 +240,7 @@ export class AhkProcessRequestTool {
             response += 'The file is now set as active. You can:\n';
             response += '• Use edit tools to modify the script\n';
             response += '• Run diagnostics to check for issues\n';
-            response += '• Execute the script with ahk_run\n';
+            response += '• Execute the script with AHK_Run\n';
             break;
             
           case 'view':
@@ -276,7 +276,7 @@ export class AhkProcessRequestTool {
       };
       
     } catch (error) {
-      logger.error('Error in ahk_process_request tool:', error);
+      logger.error('Error in AHK_Process_Request tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-run-script.ts
+++ b/src/tools/ahk-run-script.ts
@@ -30,7 +30,7 @@ export const AhkRunArgsSchema = z.object({
 });
 
 export const ahkRunToolDefinition = {
-  name: 'ahk_run',
+  name: 'AHK_Run',
   description: `Ahk run
 Run an AutoHotkey v2 script, or watch a file and auto-run it after edits.`,
   inputSchema: {
@@ -543,7 +543,7 @@ Get
         throw new Error(`Failed to start file watcher: ${watchErr instanceof Error ? watchErr.message : String(watchErr)}`);
       }
     } catch (error) {
-      logger.error('Error in ahk_run tool:', error);
+      logger.error('Error in AHK_Run tool:', error);
       
       // Provide more helpful error messages
       let errorMessage = 'Unknown error occurred';

--- a/src/tools/ahk-system-alpha.ts
+++ b/src/tools/ahk-system-alpha.ts
@@ -15,7 +15,7 @@ export const AhkAlphaArgsSchema = z.object({
 });
 
 export const ahkAlphaToolDefinition = {
-  name: 'ahk_alpha',
+  name: 'AHK_Alpha',
   description: `Ahk alpha
 Create and manage alpha versions of scripts for iterative development`,
   inputSchema: {
@@ -55,7 +55,7 @@ export class AhkAlphaTool {
   async execute(args: z.infer<typeof AhkAlphaArgsSchema>): Promise<any> {
     try {
       // Check if tool is enabled
-      const availability = checkToolAvailability('ahk_alpha');
+      const availability = checkToolAvailability('AHK_Alpha');
       if (!availability.enabled) {
         return {
           content: [{ type: 'text', text: availability.message || 'Tool is disabled' }]
@@ -67,7 +67,7 @@ export class AhkAlphaTool {
       // Get the target file
       const targetFile = filePath || activeFile.getActiveFile();
       if (!targetFile) {
-        throw new Error('No file specified and no active file set. Use ahk_file to set an active file first.');
+        throw new Error('No file specified and no active file set. Use AHK_File_Active to set an active file first.');
       }
       
       switch (action) {
@@ -264,7 +264,7 @@ export class AhkAlphaTool {
       }
       
     } catch (error) {
-      logger.error('Error in ahk_alpha tool:', error);
+      logger.error('Error in AHK_Alpha tool:', error);
       return {
         content: [{
           type: 'text',

--- a/src/tools/ahk-system-config.ts
+++ b/src/tools/ahk-system-config.ts
@@ -9,7 +9,7 @@ export const AhkConfigArgsSchema = z.object({
 });
 
 export const ahkConfigToolDefinition = {
-  name: 'ahk_config',
+  name: 'AHK_Config',
   description: `Ahk config
 Get/Set MCP configuration for A_ScriptDir and additional search directories.`,
   inputSchema: {
@@ -53,7 +53,7 @@ export class AhkConfigTool {
         ],
       };
     } catch (error) {
-      logger.error('Error in ahk_config tool:', error);
+      logger.error('Error in AHK_Config tool:', error);
       return {
         content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }]
       };

--- a/src/tools/ahk-system-settings.ts
+++ b/src/tools/ahk-system-settings.ts
@@ -29,7 +29,7 @@ export const AhkSettingsArgsSchema = z.object({
 });
 
 export const ahkSettingsToolDefinition = {
-  name: 'ahk_settings',
+  name: 'AHK_Settings',
   description: `Ahk settings
 Manage tool settings and enable/disable features`,
   inputSchema: {
@@ -86,14 +86,24 @@ export class AhkSettingsTool {
           
           // File editing tools status
           response += '**📝 File Editing Tools:**\n';
-          const fileTools = ['ahk_edit', 'ahk_diff_edit', 'ahk_file', 'ahk_auto_file', 'ahk_active_file', 'ahk_process_request', 'ahk_small_edit'];
+          const fileTools = [
+            'AHK_File_Edit',
+            'AHK_File_Edit_Diff',
+            'AHK_File_Edit_Advanced',
+            'AHK_File_Edit_Small',
+            'AHK_File_View',
+            'AHK_File_Detect',
+            'AHK_File_Active',
+            'AHK_Active_File',
+            'AHK_Process_Request'
+          ];
           for (const t of fileTools) {
             const status = currentSettings.enabledTools[t] ? '✅' : '❌';
             response += `  ${status} ${t}\n`;
           }
           
           response += '\n**🔧 Core Tools:** (always enabled)\n';
-          const coreTools = ['ahk_diagnostics', 'ahk_analyze', 'ahk_run', 'ahk_summary'];
+          const coreTools = ['AHK_Diagnostics', 'AHK_Analyze', 'AHK_Run', 'AHK_Summary'];
           for (const t of coreTools) {
             response += `  ✅ ${t}\n`;
           }
@@ -134,7 +144,7 @@ export class AhkSettingsTool {
           }
           
           // Prevent disabling core tools
-          const coreTools = ['ahk_diagnostics', 'ahk_analyze', 'ahk_run', 'ahk_summary', 'ahk_settings'];
+          const coreTools = ['AHK_Diagnostics', 'AHK_Analyze', 'AHK_Run', 'AHK_Summary', 'AHK_Settings'];
           if (coreTools.includes(tool)) {
             return {
               content: [{
@@ -158,7 +168,7 @@ export class AhkSettingsTool {
           return {
             content: [{
               type: 'text',
-              text: '✅ File editing tools have been enabled:\n• ahk_edit\n• ahk_diff_edit\n• ahk_file\n• ahk_auto_file\n• ahk_active_file\n• ahk_process_request\n• ahk_small_edit'
+              text: '✅ File editing tools have been enabled:\n• AHK_File_Edit\n• AHK_File_Edit_Diff\n• AHK_File_Edit_Advanced\n• AHK_File_Edit_Small\n• AHK_File_View\n• AHK_File_Detect\n• AHK_File_Active\n• AHK_Active_File\n• AHK_Process_Request'
             }]
           };
         }
@@ -168,7 +178,7 @@ export class AhkSettingsTool {
           return {
             content: [{
               type: 'text',
-              text: '❌ File editing tools have been disabled:\n• ahk_edit\n• ahk_diff_edit\n• ahk_file\n• ahk_auto_file\n• ahk_active_file\n• ahk_process_request\n• ahk_small_edit\n\nCore analysis and diagnostic tools remain enabled.'
+              text: '❌ File editing tools have been disabled:\n• AHK_File_Edit\n• AHK_File_Edit_Diff\n• AHK_File_Edit_Advanced\n• AHK_File_Edit_Small\n• AHK_File_View\n• AHK_File_Detect\n• AHK_File_Active\n• AHK_Active_File\n• AHK_Process_Request\n\nCore analysis and diagnostic tools remain enabled.'
             }]
           };
         }
@@ -212,7 +222,7 @@ export class AhkSettingsTool {
         
         case 'disable_all': {
           // Disable only non-core tools
-          const coreTools = ['ahk_diagnostics', 'ahk_analyze', 'ahk_run', 'ahk_summary', 'ahk_settings'];
+          const coreTools = ['AHK_Diagnostics', 'AHK_Analyze', 'AHK_Run', 'AHK_Summary', 'AHK_Settings'];
           const allSettings = toolSettings.getSettings();
           
           for (const toolName in allSettings.enabledTools) {
@@ -227,7 +237,7 @@ export class AhkSettingsTool {
           return {
             content: [{
               type: 'text',
-              text: '❌ All non-core tools have been disabled.\n\nCore tools remain enabled:\n• ahk_diagnostics\n• ahk_analyze\n• ahk_run\n• ahk_summary\n• ahk_settings'
+              text: '❌ All non-core tools have been disabled.\n\nCore tools remain enabled:\n• AHK_Diagnostics\n• AHK_Analyze\n• AHK_Run\n• AHK_Summary\n• AHK_Settings'
             }]
           };
         }
@@ -264,7 +274,7 @@ export class AhkSettingsTool {
       }
       
     } catch (error) {
-      logger.error('Error in ahk_settings tool:', error);
+      logger.error('Error in AHK_Settings tool:', error);
       return {
         content: [{
           type: 'text',


### PR DESCRIPTION
## Summary
- switch the MCP dispatcher, tool definitions, and helper utilities to the new `AHK_*` naming convention so chained tool calls resolve correctly
- refresh documentation, examples, tests, and demos to highlight the uppercase tool identifiers and prevent case-sensitivity confusion
- update tool settings defaults and enablement messaging to reflect the canonical tool names and keep file-editing groups in sync

## Testing
- npm run build
- npm run lint *(fails: existing lint violations in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d3562a0b58832ba2fd02486917ad2a