### PR TITLE
README docs + MCP follow-up features: per-session tasks, progress and log notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 # AutoHotkey v2 MCP Server
 
-A TypeScript MCP server for AutoHotkey v2 development.
-It provides script analysis, file operations, documentation search, and script execution tools for MCP clients such as Claude Desktop.
+A TypeScript MCP server for AutoHotkey v2 development. It provides script
+analysis, file operations, documentation search, and script execution tools for
+MCP clients such as Claude Desktop.
 
 [![Features](https://img.shields.io/badge/Features-blue?style=for-the-badge)](#highlights)
 [![Install](https://img.shields.io/badge/Install-green?style=for-the-badge)](#installation)
@@ -23,7 +24,9 @@ It provides script analysis, file operations, documentation search, and script e
 - Script execution with process tracking and window detection
 - Local AutoHotkey validation and diagnostics tools
 - Built-in AutoHotkey docs and prompt/context helpers
-- Stdio and SSE transport support
+- Stdio and Streamable HTTP transports (stateful or stateless), plus legacy SSE
+  endpoints
+- Opt-in bearer-token auth and DNS-rebinding protection for HTTP mode
 
 ## Requirements
 
@@ -57,6 +60,35 @@ Smoke test:
 ```bash
 npm run smoke:mcp
 ```
+
+## HTTP Mode and Environment Variables
+
+`npm start` speaks stdio (Claude Desktop). To expose Streamable HTTP on `/mcp`
+(plus legacy SSE endpoints), set `PORT` or pass `--sse`:
+
+```bash
+npm run start:sse
+```
+
+Behavior is controlled with environment variables:
+
+| Variable                    | Default   | Purpose                                                                                                                            |
+| --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                      | `3000`    | HTTP port; setting it enables HTTP mode                                                                                            |
+| `AHK_MCP_STATELESS`         | off       | `true` runs `/mcp` in the MCP spec's stateless mode: no `mcp-session-id`, a fresh transport per `POST`, safe behind load balancers |
+| `AHK_MCP_AUTH_TOKEN`        | unset     | When set, every HTTP request must send `Authorization: Bearer <token>`; unset means **no authentication**                          |
+| `AHK_MCP_ALLOWED_HOSTS`     | unset     | Comma-separated `Host` allowlist; enables DNS-rebinding protection (e.g. `localhost:3000,127.0.0.1:3000`)                          |
+| `AHK_MCP_ALLOWED_ORIGINS`   | unset     | Comma-separated `Origin` allowlist for browser clients                                                                             |
+| `AHK_MCP_TASK_RETENTION_MS` | `1800000` | How long finished task records are kept (30 min); `0` keeps them until process exit                                                |
+| `AHK_MCP_LOG_LEVEL`         | `warn`    | `error`, `warn`, `info`, or `debug`                                                                                                |
+
+Security note: the tool surface includes file writes and process execution. If
+the HTTP port is reachable by anything other than your own machine, set
+`AHK_MCP_AUTH_TOKEN` (e.g. `openssl rand -hex 32`) and the two allowlists — by
+default the endpoints accept every request.
+
+See `docs/MCP_TRANSPORT_COMPATIBILITY.md` for the session flow, stateless mode
+details, and cURL examples.
 
 ## Claude Desktop Configuration
 
@@ -131,5 +163,3 @@ See `CONTRIBUTING.md` and `AGENTS.md`.
 ## License
 
 MIT. See `LICENSE`.
-
-

--- a/Tests/unit/progress-notifier.test.ts
+++ b/Tests/unit/progress-notifier.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  ProgressNotifier,
+  extractProgressToken,
+  getProgressTokenFromArgs,
+  type ProgressNotification,
+} from '../../src/core/progress-notifier.js';
+
+describe('ProgressNotifier', () => {
+  let notifier: ProgressNotifier;
+  let sent: ProgressNotification[];
+
+  beforeEach(() => {
+    notifier = new ProgressNotifier();
+    sent = [];
+  });
+
+  const sender = async (notification: ProgressNotification) => {
+    sent.push(notification);
+  };
+
+  it('delivers notifications to the sender registered for the token', async () => {
+    notifier.register('tok-1', sender);
+    await notifier.notify('tok-1', { progress: 3, total: 10, message: 'working' });
+
+    expect(sent).toEqual([
+      {
+        method: 'notifications/progress',
+        params: { progressToken: 'tok-1', progress: 3, total: 10, message: 'working' },
+      },
+    ]);
+  });
+
+  it('drops notifications for unregistered tokens', async () => {
+    await notifier.notify('unknown', { progress: 1 });
+    expect(sent).toEqual([]);
+  });
+
+  it('stops delivering after unregister', async () => {
+    notifier.register('tok-1', sender);
+    notifier.unregister('tok-1');
+    await notifier.notify('tok-1', { progress: 1 });
+    expect(sent).toEqual([]);
+  });
+
+  it('keeps senders isolated per token', async () => {
+    const other: ProgressNotification[] = [];
+    notifier.register('a', sender);
+    notifier.register('b', async notification => {
+      other.push(notification);
+    });
+
+    await notifier.notify('b', { progress: 5 });
+
+    expect(sent).toEqual([]);
+    expect(other).toHaveLength(1);
+    expect(other[0].params.progressToken).toBe('b');
+  });
+
+  it('swallows sender failures (best-effort delivery)', async () => {
+    notifier.register('tok-1', async () => {
+      throw new Error('transport closed');
+    });
+    await expect(notifier.notify('tok-1', { progress: 1 })).resolves.toBeUndefined();
+  });
+});
+
+describe('token extraction helpers', () => {
+  it('extracts progressToken from request params _meta', () => {
+    expect(extractProgressToken({ _meta: { progressToken: 'abc' } })).toBe('abc');
+    expect(extractProgressToken({ _meta: { progressToken: 7 } })).toBe(7);
+    expect(extractProgressToken({ _meta: {} })).toBeUndefined();
+    expect(extractProgressToken({})).toBeUndefined();
+    expect(extractProgressToken(null)).toBeUndefined();
+  });
+
+  it('extracts the injected _progressToken from tool args', () => {
+    expect(getProgressTokenFromArgs({ _progressToken: 'abc' })).toBe('abc');
+    expect(getProgressTokenFromArgs({})).toBeUndefined();
+    expect(getProgressTokenFromArgs(undefined)).toBeUndefined();
+  });
+});

--- a/src/core/progress-notifier.ts
+++ b/src/core/progress-notifier.ts
@@ -3,7 +3,6 @@
  * @see https://spec.modelcontextprotocol.io/2024-11-05/server/utilities/progress/
  */
 
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import logger from '../logger.js';
 
 export interface ProgressInfo {
@@ -37,30 +36,52 @@ export function extractProgressToken(request: unknown): string | number | undefi
   return undefined;
 }
 
+export interface ProgressNotification {
+  method: 'notifications/progress';
+  params: {
+    progressToken: string | number;
+    progress: number;
+    total?: number;
+    message?: string;
+  };
+}
+
+export type ProgressSender = (notification: ProgressNotification) => Promise<void>;
+
 /**
- * Progress notification helper for long-running operations
+ * Progress notification helper for long-running operations.
+ *
+ * Senders are registered per progressToken by the tools/call handler, so
+ * notifications reach the session that issued the request even when the
+ * process serves multiple sessions.
  */
 export class ProgressNotifier {
-  private server: Server | null = null;
+  private senders = new Map<string | number, ProgressSender>();
 
   /**
-   * Initialize with MCP server instance
+   * Register the sender for a client-supplied progressToken.
+   * Call unregister once the request (or its task) finishes.
    */
-  setServer(server: Server): void {
-    this.server = server;
+  register(progressToken: string | number, sender: ProgressSender): void {
+    this.senders.set(progressToken, sender);
+  }
+
+  unregister(progressToken: string | number): void {
+    this.senders.delete(progressToken);
   }
 
   /**
    * Send a progress notification to the client
    */
   async notify(progressToken: string | number, info: ProgressInfo): Promise<void> {
-    if (!this.server) {
-      logger.debug('ProgressNotifier: No server set, skipping notification');
+    const send = this.senders.get(progressToken);
+    if (!send) {
+      logger.debug('ProgressNotifier: No sender registered for token, skipping notification');
       return;
     }
 
     try {
-      await this.server.notification({
+      await send({
         method: 'notifications/progress',
         params: {
           progressToken,

--- a/src/core/tool-metadata.ts
+++ b/src/core/tool-metadata.ts
@@ -144,7 +144,9 @@ const TOOL_METADATA: ToolMetadataEntry[] = [
   entry(ahkVSCodeProblemsToolDefinition, 'vscode-problems', 'analysis'),
   entry(ahkLintToolDefinition, 'lint', 'analysis'),
   entry(ahkThqbyDocumentSymbolsToolDefinition, 'thqby-document-symbols', 'analysis'),
-  // entry(ahkDiagnosticsToolDefinition, 'diagnostics', 'analysis'), // Hidden: use lint instead
+  // Listed because the README documents it as a core tool; AHK_Lint remains the
+  // preferred entry point for pure linting.
+  entry(ahkDiagnosticsToolDefinition, 'diagnostics', 'analysis'),
 
   // Docs (readOnly, idempotent)
   entry(ahkPromptsToolDefinition, 'prompts', 'docs'),
@@ -155,7 +157,9 @@ const TOOL_METADATA: ToolMetadataEntry[] = [
   // Execution (destructive, openWorld)
   entry(ahkDebugAgentToolDefinition, 'run-debug', 'execution'),
   entry(ahkCloudValidateToolDefinition, 'cloud-validate', 'execution'),
-  // entry(ahkRunToolDefinition, 'run-script', 'execution'), // Hidden: use run-debug instead
+  // Listed because the README documents it as a core tool; AHK_Debug_Agent
+  // remains the richer debug-oriented runner.
+  entry(ahkRunToolDefinition, 'run-script', 'execution'),
   // entry(ahkTestInteractiveToolDefinition, 'test-interactive', 'execution'), // Hidden: dev-only
 
   // Debug (destructive, openWorld)

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,15 @@ import { observabilityServer } from './core/observability-server.js';
 import './core/opentelemetry.js'; // Initialize OpenTelemetry (if enabled)
 import { tracer } from './core/tracing.js';
 import { getToolDefinitionsWithAnnotations, getToolMetadata } from './core/tool-metadata.js';
+import { extractProgressToken, progressNotifier } from './core/progress-notifier.js';
 import { InMemoryEventStore } from './core/in-memory-event-store.js';
+
+type ClientLogNotifier = {
+  server: Server;
+  setLevel(level: string): void;
+  error(data: Record<string, unknown>): void;
+  warning(data: Record<string, unknown>): void;
+};
 
 type StreamableSessionEntry = {
   protocol: 'streamable';
@@ -96,7 +104,6 @@ type SessionEntry = StreamableSessionEntry | SseSessionEntry;
 export class AutoHotkeyMcpServer {
   private server: Server;
   private toolRegistry: ToolRegistry;
-  private taskManager: TaskManager;
   public ahkDiagnosticsToolInstance: AhkDiagnosticsTool;
   public ahkSummaryToolInstance: AhkSummaryTool;
   public ahkPromptsToolInstance: AhkPromptsTool;
@@ -174,7 +181,6 @@ export class AutoHotkeyMcpServer {
     this.ahkDebugDBGpToolInstance = new AhkDebugDBGpTool();
 
     this.toolRegistry = new ToolRegistry(this);
-    this.taskManager = new TaskManager();
 
     // Initialize workflow tool with dependencies (must be after other tools are initialized)
     this.ahkWorkflowAnalyzeFixRunToolInstance = new AhkWorkflowAnalyzeFixRunTool(
@@ -220,25 +226,79 @@ export class AutoHotkeyMcpServer {
       }
     );
 
-    this.setupToolHandlers(server);
-    this.setupTaskHandlers(server);
+    // Task records and client-facing log state are scoped to this server
+    // instance, i.e. per session in HTTP mode.
+    const taskManager = new TaskManager();
+    const clientLog = this.createClientLogNotifier(server);
+
+    this.setupToolHandlers(server, taskManager, clientLog);
+    this.setupTaskHandlers(server, taskManager);
     this.setupPromptHandlers(server);
     this.setupResourceHandlers(server);
     this.setupCompletionHandlers(server);
-    this.setupLoggingHandlers(server);
+    this.setupLoggingHandlers(clientLog);
 
     return server;
   }
 
   /**
-   * Setup logging handlers to prevent "Method not found" errors
+   * Client-facing logging via notifications/message, honoring the minimum
+   * level the client requested through logging/setLevel.
    */
-  private setupLoggingHandlers(server: Server): void {
-    // Handle logging/setLevel requests (sent by some clients during initialization)
-    // We acknowledge the request but use our own server-side logging
+  private createClientLogNotifier(server: Server): ClientLogNotifier {
+    const levels = [
+      'debug',
+      'info',
+      'notice',
+      'warning',
+      'error',
+      'critical',
+      'alert',
+      'emergency',
+    ];
+    let minLevel = 'info';
+
+    const send = (level: string, data: Record<string, unknown>): void => {
+      if (levels.indexOf(level) < levels.indexOf(minLevel)) {
+        return;
+      }
+
+      try {
+        void server
+          .sendLoggingMessage({
+            level: level as Parameters<Server['sendLoggingMessage']>[0]['level'],
+            logger: 'ahk-mcp',
+            data,
+          })
+          .catch(error => {
+            logger.debug(`Client log notification failed: ${error}`);
+          });
+      } catch (error) {
+        logger.debug(`Client log notification failed: ${error}`);
+      }
+    };
+
+    return {
+      server,
+      setLevel: level => {
+        if (levels.includes(level)) {
+          minLevel = level;
+        }
+      },
+      error: data => send('error', data),
+      warning: data => send('warning', data),
+    };
+  }
+
+  /**
+   * Setup logging handlers
+   */
+  private setupLoggingHandlers(clientLog: ClientLogNotifier): void {
+    const server = clientLog.server;
     server.setRequestHandler(SetLevelRequestSchema, async request => {
       const level = request.params.level;
-      logger.debug(`Client requested log level: ${level} (using server-side logging)`);
+      clientLog.setLevel(level);
+      logger.debug(`Client requested log level: ${level}`);
       return {};
     });
 
@@ -252,7 +312,11 @@ export class AutoHotkeyMcpServer {
   /**
    * Setup MCP tool handlers
    */
-  private setupToolHandlers(server: Server): void {
+  private setupToolHandlers(
+    server: Server,
+    taskManager: TaskManager,
+    clientLog: ClientLogNotifier
+  ): void {
     // List tools handler
     server.setRequestHandler(ListToolsRequestSchema, async () => {
       logger.debug('Listing available AutoHotkey tools');
@@ -334,12 +398,25 @@ export class AutoHotkeyMcpServer {
     });
 
     // Call tool handler
-    server.setRequestHandler(CallToolRequestSchema, async request => {
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const params = request.params as typeof request.params & { task?: { ttl?: number } };
       const { name, arguments: args } = params;
       const taskRequest = params.task;
       const startTime = Date.now();
       const toolTimeoutMs = envConfig.getToolTimeoutMs();
+
+      // Route notifications/progress to this request's session for the
+      // duration of the call; tools read the token via _progressToken.
+      const progressToken = extractProgressToken(params);
+      const toolArgs =
+        progressToken !== undefined && args && typeof args === 'object'
+          ? { ...(args as Record<string, unknown>), _progressToken: progressToken }
+          : args;
+      if (progressToken !== undefined) {
+        progressNotifier.register(progressToken, notification =>
+          extra.sendNotification(notification)
+        );
+      }
 
       // Unified logging: generate call ID and log start
       const callId = `${name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -367,11 +444,19 @@ export class AutoHotkeyMcpServer {
           const pollInterval = envConfig.getTaskPollIntervalMs();
           const taskTimeoutMs = ttl ?? envConfig.getTaskTimeoutMs();
 
-          const task = this.taskManager.createTask({
+          const task = taskManager.createTask({
             toolName: name,
             ttl,
             pollInterval,
-            execute: () => this.executeToolWithTimeout(name, args, taskTimeoutMs),
+            execute: async () => {
+              try {
+                return await this.executeToolWithTimeout(name, toolArgs, taskTimeoutMs);
+              } finally {
+                if (progressToken !== undefined) {
+                  progressNotifier.unregister(progressToken);
+                }
+              }
+            },
           });
 
           // Unified logging: task queued (execution is async)
@@ -394,7 +479,7 @@ export class AutoHotkeyMcpServer {
                 : 0;
 
             // Execute the tool
-            const toolResult = await this.executeToolWithTimeout(name, args, toolTimeoutMs);
+            const toolResult = await this.executeToolWithTimeout(name, toolArgs, toolTimeoutMs);
 
             // Add result metadata to span
             if (toolResult && toolResult.content) {
@@ -414,6 +499,11 @@ export class AutoHotkeyMcpServer {
         // Unified logging: log error
         unifiedLog.toolError(callId, error instanceof Error ? error : new Error(String(error)));
 
+        clientLog.error({
+          tool: name,
+          message: error instanceof Error ? error.message : String(error),
+        });
+
         // Build rich error response with metadata
         return ErrorResponseBuilder.fromError(error, ErrorCode.TOOL_EXECUTION_FAILED)
           .tool(request.params.name)
@@ -423,6 +513,11 @@ export class AutoHotkeyMcpServer {
             arguments: request.params.arguments,
           })
           .build();
+      } finally {
+        // Task-based calls unregister when the task finishes instead.
+        if (!taskRequest && progressToken !== undefined) {
+          progressNotifier.unregister(progressToken);
+        }
       }
     });
   }
@@ -430,7 +525,7 @@ export class AutoHotkeyMcpServer {
   /**
    * Setup MCP task handlers
    */
-  private setupTaskHandlers(server: Server): void {
+  private setupTaskHandlers(server: Server, taskManager: TaskManager): void {
     const taskStatusValues = ['working', 'completed', 'failed', 'canceled'] as const;
     const TaskStatusSchema = z.enum(taskStatusValues);
 
@@ -466,13 +561,13 @@ export class AutoHotkeyMcpServer {
 
     server.setRequestHandler(TaskListRequestSchema, async request => {
       const status = request.params?.status;
-      const tasks = this.taskManager.listTasks(status);
+      const tasks = taskManager.listTasks(status);
       return { tasks };
     });
 
     server.setRequestHandler(TaskGetRequestSchema, async request => {
       const { taskId } = request.params;
-      const task = this.taskManager.getTask(taskId);
+      const task = taskManager.getTask(taskId);
       if (!task) {
         throw new Error(`Task not found: ${taskId}`);
       }
@@ -481,7 +576,7 @@ export class AutoHotkeyMcpServer {
 
     server.setRequestHandler(TaskCancelRequestSchema, async request => {
       const { taskId } = request.params;
-      const task = this.taskManager.cancelTask(taskId);
+      const task = taskManager.cancelTask(taskId);
       if (!task) {
         throw new Error(`Task not found: ${taskId}`);
       }
@@ -490,7 +585,7 @@ export class AutoHotkeyMcpServer {
 
     server.setRequestHandler(TaskResultRequestSchema, async request => {
       const { taskId } = request.params;
-      const outcome = this.taskManager.getTaskResult(taskId);
+      const outcome = taskManager.getTaskResult(taskId);
       if (!outcome) {
         throw new Error(`Task not found: ${taskId}`);
       }


### PR DESCRIPTION
## Summary

Follow-up to #11 in two parts.

### Docs (commit 1)

- New **"HTTP Mode and Environment Variables"** README section: how to enable HTTP mode, plus a table covering `PORT`, `AHK_MCP_STATELESS`, `AHK_MCP_AUTH_TOKEN`, `AHK_MCP_ALLOWED_HOSTS`, `AHK_MCP_ALLOWED_ORIGINS`, `AHK_MCP_TASK_RETENTION_MS`, and `AHK_MCP_LOG_LEVEL`, with a security note that the endpoints accept every request until a token is set
- Updated the stale "Stdio and SSE transport support" highlight; README reflowed by prettier (80-col markdown prose)

### Features (commit 2) — the best remaining items from the #11 architecture review

- **Per-session `TaskManager`**: created inside `createServer()` so task records are scoped per server instance (per session in HTTP mode). Previously one process-wide manager let any session list, read, and cancel another session's tasks.
- **Real `notifications/progress`**: the `tools/call` handler now registers a per-token sender bound to the requesting session and injects `_progressToken` into tool args, so the progress calls already present in the lint/analyze/orchestrator tools actually reach clients. `ProgressNotifier` drops its never-called `setServer` design; task-based calls keep their sender registered until the task finishes.
- **Real `notifications/message`**: tool failures now emit client log notifications via `sendLoggingMessage`, honoring the minimum level the client sets through `logging/setLevel` — the declared `logging` capability previously never sent anything.
- **Tool-list consistency**: `AHK_Run` and `AHK_Diagnostics` are documented as core tools in the README but were hidden from `tools/list` while remaining callable; they are now listed (with proper execution/analysis annotations).

## Test plan

- `npm run build`, `tsc --noEmit` (now fully clean, zero errors), `npm run lint` (0 errors), `npx prettier --check "src/**/*.ts"` — all pass
- New `Tests/unit/progress-notifier.test.ts` (7 tests: per-token routing, isolation, unregister, best-effort failure handling); `task-manager` and `env-config` suites still pass
- Full unit run shows the same 12 pre-existing failures as master (missing fixtures/removed exports predating this branch) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeGH6ALW8xtzCTZeLaysmr